### PR TITLE
Change vararg functions to void functions

### DIFF
--- a/avrogenc/src/main/resources/record.c.vm
+++ b/avrogenc/src/main/resources/record.c.vm
@@ -173,7 +173,7 @@ static size_t ${prefix}_${record_name}_get_size(void *data)
 }
 #end
 
-${prefix}_${record_name}_t *${prefix}_${record_name}_create()
+${prefix}_${record_name}_t *${prefix}_${record_name}_create(void)
 {
     ${prefix}_${record_name}_t *record = 
             (${prefix}_${record_name}_t *)KAA_CALLOC(1, sizeof(${prefix}_${record_name}_t));

--- a/avrogenc/src/main/resources/record.h.vm
+++ b/avrogenc/src/main/resources/record.h.vm
@@ -31,7 +31,7 @@ typedef struct {
 } ${prefix}_${record_name}_t;
 
 #if ($TypeConverter.isTypeOut($schema))
-${prefix}_${record_name}_t *${prefix}_${record_name}_create();
+${prefix}_${record_name}_t *${prefix}_${record_name}_create(void);
 #end
 #if ($TypeConverter.isTypeIn($schema))
 ${prefix}_${record_name}_t *${prefix}_${record_name}_deserialize(avro_reader_t reader);

--- a/avrogenc/src/main/resources/union.c.vm
+++ b/avrogenc/src/main/resources/union.c.vm
@@ -221,7 +221,7 @@ static void ${union_name}_serialize(avro_writer_t writer, void *data)
     }
 }
 #end
-static kaa_union_t *${union_name}_create()
+static kaa_union_t *${union_name}_create(void)
 {
     kaa_union_t *kaa_union = KAA_CALLOC(1, sizeof(kaa_union_t));
 
@@ -239,7 +239,7 @@ static kaa_union_t *${union_name}_create()
 #set ($branch_number = 0)
 #foreach ($branch_schema in $schema.getTypes())
 
-kaa_union_t *${union_name}_branch_${branch_number}_create()
+kaa_union_t *${union_name}_branch_${branch_number}_create(void)
 {
     kaa_union_t *kaa_union = ${union_name}_create();
     if (kaa_union) {

--- a/avrogenc/src/main/resources/union.h.vm
+++ b/avrogenc/src/main/resources/union.h.vm
@@ -30,7 +30,7 @@
 #set ($branch_number = 0)
 #if ($generationContext.isTypeOut())
 #foreach ($branch_schema in $schema.getTypes())
-kaa_union_t *${union_name}_branch_${branch_number}_create();
+kaa_union_t *${union_name}_branch_${branch_number}_create(void);
 #set ($branch_number = $branch_number + 1)
 #end
 

--- a/client/client-multi/client-c/src/kaa/collections/kaa_list.h
+++ b/client/client-multi/client-c/src/kaa/collections/kaa_list.h
@@ -48,7 +48,7 @@ typedef void (*process_data)(void *data, void *context);
  * @brief Creates empty list.
  * @return The list object.
  */
-kaa_list_t *kaa_list_create();
+kaa_list_t *kaa_list_create(void);
 
 /**
  * @brief Destroys list and all elements.

--- a/client/client-multi/client-c/src/kaa/gen/kaa_configuration_gen.c
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_configuration_gen.c
@@ -93,7 +93,7 @@ static void kaa_union_null_or_fixed_serialize(avro_writer_t writer, void *data)
         }
     }
 }
-static kaa_union_t *kaa_union_null_or_fixed_create()
+static kaa_union_t *kaa_union_null_or_fixed_create(void)
 {
     kaa_union_t *kaa_union = KAA_CALLOC(1, sizeof(kaa_union_t));
 
@@ -106,7 +106,7 @@ static kaa_union_t *kaa_union_null_or_fixed_create()
     return kaa_union; 
 }
 
-kaa_union_t *kaa_union_null_or_fixed_branch_0_create()
+kaa_union_t *kaa_union_null_or_fixed_branch_0_create(void)
 {
     kaa_union_t *kaa_union = kaa_union_null_or_fixed_create();
     if (kaa_union) {
@@ -115,7 +115,7 @@ kaa_union_t *kaa_union_null_or_fixed_branch_0_create()
     return kaa_union;
 }
 
-kaa_union_t *kaa_union_null_or_fixed_branch_1_create()
+kaa_union_t *kaa_union_null_or_fixed_branch_1_create(void)
 {
     kaa_union_t *kaa_union = kaa_union_null_or_fixed_create();
     if (kaa_union) {
@@ -187,7 +187,7 @@ static size_t kaa_configuration_root_record_get_size(void *data)
     return 0;
 }
 
-kaa_configuration_root_record_t *kaa_configuration_root_record_create()
+kaa_configuration_root_record_t *kaa_configuration_root_record_create(void)
 {
     kaa_configuration_root_record_t *record = 
             (kaa_configuration_root_record_t *)KAA_CALLOC(1, sizeof(kaa_configuration_root_record_t));

--- a/client/client-multi/client-c/src/kaa/gen/kaa_configuration_gen.h
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_configuration_gen.h
@@ -31,8 +31,8 @@ extern "C" {
 # define KAA_UNION_NULL_OR_FIXED_BRANCH_0    0
 # define KAA_UNION_NULL_OR_FIXED_BRANCH_1    1
 
-kaa_union_t *kaa_union_null_or_fixed_branch_0_create();
-kaa_union_t *kaa_union_null_or_fixed_branch_1_create();
+kaa_union_t *kaa_union_null_or_fixed_branch_0_create(void);
+kaa_union_t *kaa_union_null_or_fixed_branch_1_create(void);
 
 kaa_union_t *kaa_union_null_or_fixed_deserialize(avro_reader_t reader);
 
@@ -48,7 +48,7 @@ typedef struct {
     destroy_fn   destroy;
 } kaa_configuration_root_record_t;
 
-kaa_configuration_root_record_t *kaa_configuration_root_record_create();
+kaa_configuration_root_record_t *kaa_configuration_root_record_create(void);
 kaa_configuration_root_record_t *kaa_configuration_root_record_deserialize(avro_reader_t reader);
 
 #ifdef __cplusplus

--- a/client/client-multi/client-c/src/kaa/gen/kaa_logging_gen.c
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_logging_gen.c
@@ -60,7 +60,7 @@ static size_t kaa_test_log_record_get_size(void *data)
     return 0;
 }
 
-kaa_test_log_record_t *kaa_test_log_record_create()
+kaa_test_log_record_t *kaa_test_log_record_create(void)
 {
     kaa_test_log_record_t *record = 
             (kaa_test_log_record_t *)KAA_CALLOC(1, sizeof(kaa_test_log_record_t));

--- a/client/client-multi/client-c/src/kaa/gen/kaa_logging_gen.h
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_logging_gen.h
@@ -33,7 +33,7 @@ typedef struct {
     destroy_fn   destroy;
 } kaa_test_log_record_t;
 
-kaa_test_log_record_t *kaa_test_log_record_create();
+kaa_test_log_record_t *kaa_test_log_record_create(void);
 kaa_test_log_record_t *kaa_test_log_record_deserialize(avro_reader_t reader);
 
 #ifdef __cplusplus

--- a/client/client-multi/client-c/src/kaa/gen/kaa_notification_gen.c
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_notification_gen.c
@@ -60,7 +60,7 @@ static size_t kaa_notification_notification_get_size(void *data)
     return 0;
 }
 
-kaa_notification_notification_t *kaa_notification_notification_create()
+kaa_notification_notification_t *kaa_notification_notification_create(void)
 {
     kaa_notification_notification_t *record = 
             (kaa_notification_notification_t *)KAA_CALLOC(1, sizeof(kaa_notification_notification_t));

--- a/client/client-multi/client-c/src/kaa/gen/kaa_profile_gen.c
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_profile_gen.c
@@ -60,7 +60,7 @@ static size_t kaa_profile_basic_endpoint_profile_test_get_size(void *data)
     return 0;
 }
 
-kaa_profile_basic_endpoint_profile_test_t *kaa_profile_basic_endpoint_profile_test_create()
+kaa_profile_basic_endpoint_profile_test_t *kaa_profile_basic_endpoint_profile_test_create(void)
 {
     kaa_profile_basic_endpoint_profile_test_t *record = 
             (kaa_profile_basic_endpoint_profile_test_t *)KAA_CALLOC(1, sizeof(kaa_profile_basic_endpoint_profile_test_t));

--- a/client/client-multi/client-c/src/kaa/gen/kaa_profile_gen.h
+++ b/client/client-multi/client-c/src/kaa/gen/kaa_profile_gen.h
@@ -33,7 +33,7 @@ typedef struct {
     destroy_fn   destroy;
 } kaa_profile_basic_endpoint_profile_test_t;
 
-kaa_profile_basic_endpoint_profile_test_t *kaa_profile_basic_endpoint_profile_test_create();
+kaa_profile_basic_endpoint_profile_test_t *kaa_profile_basic_endpoint_profile_test_create(void);
 kaa_profile_basic_endpoint_profile_test_t *kaa_profile_basic_endpoint_profile_test_deserialize(avro_reader_t reader);
 
 #ifdef __cplusplus

--- a/client/client-multi/client-c/src/kaa/kaa_common_schema.c
+++ b/client/client-multi/client-c/src/kaa/kaa_common_schema.c
@@ -477,7 +477,7 @@ void kaa_null_destroy(void *data)
 {
 }
 
-size_t kaa_null_get_size()
+size_t kaa_null_get_size(void)
 {
     return AVRO_NULL_SIZE;
 }

--- a/client/client-multi/client-c/src/kaa/kaa_common_schema.h
+++ b/client/client-multi/client-c/src/kaa/kaa_common_schema.h
@@ -38,7 +38,7 @@ extern "C" {
 
 
 typedef void (*serialize_fn)(avro_writer_t writer, void *data);
-typedef void *(*deserialize_fn)();
+typedef void *(*deserialize_fn)(void);
 typedef void *(*deserialize_wo_ctx_fn)(avro_reader_t reader);
 typedef void *(*deserialize_w_ctx_fn)(avro_reader_t reader, void *context);
 typedef size_t (*get_size_fn)(void *data);
@@ -146,7 +146,7 @@ size_t kaa_array_get_size(kaa_list_t *array, get_size_fn get_size);
 void kaa_null_serialize(avro_writer_t writer, void *data);
 void *kaa_null_deserialize(avro_reader_t reader);
 void kaa_null_destroy(void *data);
-size_t kaa_null_get_size();
+size_t kaa_null_get_size(void);
 
 void kaa_data_destroy(void *data);
 

--- a/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_configuration_persistence.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_configuration_persistence.c
@@ -38,7 +38,7 @@ void ext_configuration_store(const char *buffer, size_t buffer_size)
     econais_ec19d_binary_file_store(KAA_CONFIGURATION_STORAGE, buffer, buffer_size);
 }
 
-void ext_configuration_delete() 
+void ext_configuration_delete(void)
 {
     econais_ec19d_binary_file_delete(KAA_CONFIGURATION_STORAGE);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_kaa_client.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_kaa_client.c
@@ -77,7 +77,7 @@ struct kaa_client_t {
 #include "../../../platform/kaa_client.h"
 
 //Forward declaration of internal functions
-kaa_error_t kaa_init_security_stuff();
+kaa_error_t kaa_init_security_stuff(void);
 kaa_error_t kaa_log_collector_init(kaa_client_t *kaa_client);
 
 /* forward declarations */
@@ -663,7 +663,7 @@ void ext_get_endpoint_public_key(char **buffer, size_t *buffer_size, bool *needs
 }
 
 
-kaa_error_t kaa_init_security_stuff()
+kaa_error_t kaa_init_security_stuff(void)
 {
     sndc_file_ref_t key_file = sndc_file_open(KAA_KEY_STORAGE, DE_FRDONLY);
 
@@ -812,7 +812,7 @@ void ext_write_log(FILE * sink, const char * buffer, size_t message_size)
     sndc_thrd_delay(TRACE_DELAY * SNDC_MILLISECOND);
 }
 
-kaa_time_t ext_get_systime()
+kaa_time_t ext_get_systime(void)
 {
     return (time_t) sndc_sys_getTimestamp_msec() / 1000;
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_time.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_time.h
@@ -20,7 +20,7 @@
 
 typedef uint32_t kaa_time_t;
 
-kaa_time_t ext_get_systime();
+kaa_time_t ext_get_systime(void);
 
 #define KAA_TIME() ext_get_systime()
 

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_configuration_persistence.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_configuration_persistence.c
@@ -32,7 +32,7 @@ void ext_configuration_store(const char *buffer, size_t buffer_size)
     cc32xx_binary_file_store(KAA_CONFIGURATION_STORAGE, buffer, buffer_size);
 }
 
-void ext_configuration_delete(const char *buffer, size_t buffer_size)
+void ext_configuration_delete(void)
 {
     cc32xx_binary_file_delete(KAA_CONFIGURATION_STORAGE);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_reboot.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_reboot.c
@@ -18,7 +18,7 @@
 #include "device.h"
 #include "prcm.h"
 
-void cc32xx_reboot()
+void cc32xx_reboot(void)
 {
     sl_Stop(30);
     PRCMHibernateIntervalSet(330);

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_stdio.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_stdio.h
@@ -20,6 +20,6 @@
 #include <stdio.h>
 
 #define KAA_EXIT(e) cc32xx_reboot()
-void cc32xx_reboot();
+void cc32xx_reboot(void);
 
 #endif /* CC32XX_STDIO_H_ */

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_time.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_time.c
@@ -30,7 +30,7 @@ static void sysTickIntHandler(void)
     ++milliTimer;
 }
 
-void cc32xx_init_timer()
+void cc32xx_init_timer(void)
 {
     static int init = 0;
 
@@ -43,13 +43,13 @@ void cc32xx_init_timer()
     }
 }
 
-long long cc32xx_clock_getms()
+long long cc32xx_clock_getms(void)
 {
     cc32xx_init_timer();
     return milliTimer;
 }
 
-long cc32xx_time()
+long cc32xx_time(void)
 {
     cc32xx_init_timer();
     return secTimer;

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_time.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/cc32xx_time.h
@@ -24,7 +24,7 @@ typedef long kaa_time_t;
 
 #define KAA_TIME() (kaa_time_t)cc32xx_time()
 
-long cc32xx_time();
-long long cc32xx_clock_getms();
+long cc32xx_time(void);
+long long cc32xx_clock_getms(void);
 
 #endif /* CC32XX_TIME_H_ */

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/logger.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/logger.c
@@ -31,7 +31,7 @@ void ext_write_log(FILE * sink, const char * buffer, size_t message_size)
     Report("%s\r",buffer);
 }
 
-time_t ext_get_systime()
+kaa_time_t ext_get_systime(void)
 {
     return KAA_TIME();
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_configuration_persistence.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_configuration_persistence.c
@@ -28,7 +28,7 @@ void ext_configuration_store(const char *buffer, size_t buffer_size) {
 
 }
 
-void ext_configuration_delete()
+void ext_configuration_delete(void)
 {
 
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_logger.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_logger.c
@@ -21,7 +21,7 @@
 
 #include "../../platform/ext_system_logger.h"
 
-kaa_time_t ext_get_systime()
+kaa_time_t ext_get_systime(void)
 {
     return system_get_rtc_time()*((system_rtc_clock_cali_proc()*1000)>>12)/1000;
 };

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_time.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_time.c
@@ -18,7 +18,7 @@
 
 #include <esp_system.h>
 
-kaa_time_t kaa_esp8266_get_time()
+kaa_time_t kaa_esp8266_get_time(void)
 {
     return (system_get_time() / 1000000);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_time.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/esp8266_time.h
@@ -19,7 +19,7 @@
 
 typedef unsigned int kaa_time_t;
 
-kaa_time_t kaa_esp8266_get_time();
+kaa_time_t kaa_esp8266_get_time(void);
 
 #define KAA_TIME() kaa_esp8266_get_time()
 

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/snprintf.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/snprintf.c
@@ -811,7 +811,7 @@ int main (void)
 }
 #endif /* SNPRINTF_TEST */
 
-void abort() {}
+void abort(void) {}
 
 #endif /* !HAVE_SNPRINTF */
 /* Shut up the compaq compiler which hates empty files. This will

--- a/client/client-multi/client-c/src/kaa/platform-impl/posix/logger.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/posix/logger.c
@@ -30,7 +30,7 @@ void ext_write_log(FILE * sink, const char * buffer, size_t message_size)
     fflush(sink);
 }
 
-time_t ext_get_systime()
+kaa_time_t ext_get_systime(void)
 {
     return time(NULL);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/posix/posix_configuration_persistence.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/posix/posix_configuration_persistence.c
@@ -32,7 +32,7 @@ void ext_configuration_store(const char *buffer, size_t buffer_size)
     posix_binary_file_store(KAA_CONFIGURATION_STORAGE, buffer, buffer_size);
 }
 
-void ext_configuration_delete()
+void ext_configuration_delete(void)
 {
     posix_binary_file_delete(KAA_CONFIGURATION_STORAGE);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/posix/posix_key_utils.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/posix/posix_key_utils.c
@@ -32,7 +32,7 @@
 static char *kaa_public_key = NULL;
 static size_t kaa_public_key_length = 0;
 
-static void kaa_generate_pub_key()
+static void kaa_generate_pub_key(void)
 {
     const int kBits = 2048;
     const int kExp = 65537;
@@ -56,7 +56,7 @@ static void kaa_generate_pub_key()
     RSA_free(rsa);
 }
 
-static int kaa_init_key()
+static int kaa_init_key(void)
 {
     struct stat stat_result;
     int key_result = stat(KAA_KEY_STORAGE, &stat_result);

--- a/client/client-multi/client-c/src/kaa/platform-impl/stm32/leafMapleMini/esp8266/chip_specififc.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/stm32/leafMapleMini/esp8266/chip_specififc.h
@@ -30,18 +30,18 @@ extern "C" {
 
 uint32_t get_sys_max(uint32_t s1, uint32_t s2);
 
-time_t get_sys_milis();
+time_t get_sys_milis(void);
 
 void debug(const char* format, ...);
 
-void ledOn();
+void ledOn(void);
 
-void ledOff();
+void ledOff(void);
 
 void lightOn(bool left, bool right);
 void lightOff(bool left, bool right);
 
-void esp8266_reset();
+void esp8266_reset(void);
 
 #ifdef __cplusplus
 }      /* extern "C" */

--- a/client/client-multi/client-c/src/kaa/platform-impl/stm32/leafMapleMini/esp8266/esp8266_kaa_client.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/stm32/leafMapleMini/esp8266/esp8266_kaa_client.c
@@ -694,5 +694,5 @@ kaa_error_t kaa_log_collector_init(kaa_client_t *kaa_client)
 }
 
 // dummy method
-void ext_configuration_delete(const char *buffer, size_t buffer_size)
+void ext_configuration_delete(void)
 {}

--- a/client/client-multi/client-c/src/kaa/platform/ext_configuration_persistence.h
+++ b/client/client-multi/client-c/src/kaa/platform/ext_configuration_persistence.h
@@ -59,7 +59,7 @@ void ext_configuration_store(const char *buffer, size_t buffer_size);
  * @brief Called when Kaa need to remove configuration data.
  *
  */
-void ext_configuration_delete();
+void ext_configuration_delete(void);
 
 
 #ifdef __cplusplus

--- a/client/client-multi/client-c/src/kaa/platform/ext_system_logger.h
+++ b/client/client-multi/client-c/src/kaa/platform/ext_system_logger.h
@@ -40,7 +40,7 @@ void ext_write_log(FILE * sink, const char * buffer, size_t message_size);
  *
  * @return  time_t      Time in seconds.
  */
-kaa_time_t ext_get_systime();
+kaa_time_t ext_get_systime(void);
 
 /**
  * @brief Put formated LOG prefix in buffer.

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -143,7 +143,7 @@ void test_check_bootstrap_sync(kaa_transport_channel_interface_t *channel);
 /*
  * Test create and destroy bootstrap channel
  */
-void test_create_kaa_tcp_channel()
+void test_create_kaa_tcp_channel(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -195,7 +195,7 @@ void test_create_kaa_tcp_channel()
  * 3. Send disconnect, check sending.
  * 4. Check socket close.
  */
-void test_set_access_point_full_success_bootstrap()
+void test_set_access_point_full_success_bootstrap(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -225,7 +225,7 @@ void test_set_access_point_full_success_bootstrap()
 /*
  * Test connecting error during set access point.
  */
-void test_set_access_point_connecting_error()
+void test_set_access_point_connecting_error(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -269,7 +269,7 @@ void test_set_access_point_connecting_error()
  * 2. Imitate IO error on read
  * 3. Close socket, check bootstrap manager access point failure notification
  */
-void test_set_access_point_io_error()
+void test_set_access_point_io_error(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -338,7 +338,7 @@ void test_set_access_point_io_error()
  * 8. Send disconnect, check sending.
  * 9. Check socket close.
  */
-void test_bootstrap_sync_success()
+void test_bootstrap_sync_success(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c
@@ -151,7 +151,7 @@ void test_sync_exchange(kaa_transport_channel_interface_t *channel);
 /*
  * Test channel creation and destroy.
  */
-void test_create_kaa_tcp_channel()
+void test_create_kaa_tcp_channel(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -210,7 +210,7 @@ void test_create_kaa_tcp_channel()
  *  2. Authorize, send CONNECT and receive CONACK
  *  3. Receive Disconnect message, check connection drop and notify Bootstrap of AP failure
  */
-void test_kaa_tcp_channel_success_flow()
+void test_kaa_tcp_channel_success_flow(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -248,7 +248,7 @@ void test_kaa_tcp_channel_success_flow()
  *  3. Call Sync for EVENT than EVENT,LOGGING, check send SYNC for EVENT,LOGGING, receive SYNC.
  *  4. Receive Disconnect message, check connection drop and notify Bootstrap manager of AP failure
  */
-void test_kaa_tcp_channel_sync_flow()
+void test_kaa_tcp_channel_sync_flow(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -302,7 +302,7 @@ void test_kaa_tcp_channel_sync_flow()
  *  4. Imitate IO error on read.
  *  5. check disconnect notification
  */
-void test_kaa_tcp_channel_io_error_flow()
+void test_kaa_tcp_channel_io_error_flow(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -355,7 +355,7 @@ void test_kaa_tcp_channel_io_error_flow()
  * 2. Call sync several times before authorization complete, check that CONNECT is generated only once.
  * 3. Disconnect.
  */
-void test_kaa_tcp_channel_auth_double_sync_flow()
+void test_kaa_tcp_channel_auth_double_sync_flow(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/kaatcp/kaatcp_parser_test.c
+++ b/client/client-multi/client-c/test/kaatcp/kaatcp_parser_test.c
@@ -72,7 +72,7 @@ void ping_listener(void *context)
     ping_received = 1;
 }
 
-void test_kaatcp_parser()
+void test_kaatcp_parser(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/kaatcp/kaatcp_request_test.c
+++ b/client/client-multi/client-c/test/kaatcp/kaatcp_request_test.c
@@ -29,7 +29,7 @@ static kaa_logger_t *logger = NULL;
 
 
 
-void test_kaatcp_connect()
+void test_kaatcp_connect(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -56,7 +56,7 @@ void test_kaatcp_connect()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaatcp_connect_without_key()
+void test_kaatcp_connect_without_key(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -79,7 +79,7 @@ void test_kaatcp_connect_without_key()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaatcp_disconnect()
+void test_kaatcp_disconnect(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -100,7 +100,7 @@ void test_kaatcp_disconnect()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaatcp_kaasync()
+void test_kaatcp_kaasync(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -123,7 +123,7 @@ void test_kaatcp_kaasync()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaatcp_ping()
+void test_kaatcp_ping(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/platform-impl/test_ext_log_storage_memory.c
+++ b/client/client-multi/client-c/test/platform-impl/test_ext_log_storage_memory.c
@@ -45,7 +45,7 @@ static kaa_logger_t *logger = NULL;
 
 
 
-void test_create_unlimited_storage()
+void test_create_unlimited_storage(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -71,7 +71,7 @@ void test_create_unlimited_storage()
 
 
 
-void test_create_limited_storage()
+void test_create_limited_storage(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -111,7 +111,7 @@ void test_create_limited_storage()
 
 
 
-void test_allocate_log_record_buffer()
+void test_allocate_log_record_buffer(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -158,7 +158,7 @@ static kaa_error_t add_log_record(void *storage, const char *data, size_t data_s
     return ext_log_storage_add_log_record(storage, &record);
 }
 
-void test_add_log_record()
+void test_add_log_record(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -192,7 +192,7 @@ void test_add_log_record()
 
 
 
-void test_write_next_log_record()
+void test_write_next_log_record(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -258,7 +258,7 @@ void test_write_next_log_record()
 
 
 
-void test_remove_by_bucket_id()
+void test_remove_by_bucket_id(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -322,7 +322,7 @@ void test_remove_by_bucket_id()
 
 
 
-void test_unmark_by_bucket_id()
+void test_unmark_by_bucket_id(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -395,7 +395,7 @@ void test_unmark_by_bucket_id()
 
 
 
-void test_shrink_to_size()
+void test_shrink_to_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -438,7 +438,7 @@ void test_shrink_to_size()
 
 
 
-int test_init()
+int test_init(void)
 {
     kaa_error_t error = kaa_log_create(&logger, KAA_MAX_LOG_MESSAGE_LENGTH, KAA_MAX_LOG_LEVEL, NULL);
     if (error || !logger) {
@@ -448,7 +448,7 @@ int test_init()
     return 0;
 }
 
-int test_deinit()
+int test_deinit(void)
 {
     kaa_log_destroy(logger);
     return 0;

--- a/client/client-multi/client-c/test/platform-impl/test_ext_log_upload_strategies.c
+++ b/client/client-multi/client-c/test/platform-impl/test_ext_log_upload_strategies.c
@@ -76,7 +76,7 @@ size_t ext_log_storage_get_records_count(const void *context)
 }
 
 
-void test_create_strategy()
+void test_create_strategy(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -101,7 +101,7 @@ void test_create_strategy()
     KAA_TRACE_OUT(logger);
 }
 
-void test_set_upload_timeout()
+void test_set_upload_timeout(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -120,7 +120,7 @@ void test_set_upload_timeout()
     KAA_TRACE_OUT(logger);
 }
 
-void test_set_batch_size()
+void test_set_batch_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -139,7 +139,7 @@ void test_set_batch_size()
     KAA_TRACE_OUT(logger);
 }
 
-void test_upload_decision_by_volume()
+void test_upload_decision_by_volume(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -174,7 +174,7 @@ void test_upload_decision_by_volume()
     KAA_TRACE_OUT(logger);
 }
 
-void test_upload_decision_by_count()
+void test_upload_decision_by_count(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -209,7 +209,7 @@ void test_upload_decision_by_count()
     KAA_TRACE_OUT(logger);
 }
 
-void test_upload_decision_by_timeout()
+void test_upload_decision_by_timeout(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -242,7 +242,7 @@ void test_upload_decision_by_timeout()
     KAA_TRACE_OUT(logger);
 }
 
-void test_noop_decision_on_failure()
+void test_noop_decision_on_failure(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -276,7 +276,7 @@ void test_noop_decision_on_failure()
     KAA_TRACE_OUT(logger);
 }
 
-void test_upload_decision_on_failure()
+void test_upload_decision_on_failure(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -355,7 +355,7 @@ static kaa_error_t test_sync_handler(void *context
     return KAA_ERR_NONE;
 }
 
-int test_init()
+int test_init(void)
 {
     kaa_error_t error = kaa_log_create(&logger, KAA_MAX_LOG_MESSAGE_LENGTH, KAA_MAX_LOG_LEVEL, NULL);
     if (error || !logger) {
@@ -383,7 +383,7 @@ int test_init()
     return 0;
 }
 
-int test_deinit()
+int test_deinit(void)
 {
     kaa_bootstrap_manager_destroy(bootstrap_manager);
     kaa_channel_manager_destroy(channel_manager);

--- a/client/client-multi/client-c/test/test_kaa_bootstrap_manager.c
+++ b/client/client-multi/client-c/test/test_kaa_bootstrap_manager.c
@@ -142,7 +142,7 @@ static void test_create_channel_interface(kaa_transport_channel_interface_t *cha
 
 
 
-void test_create_bootstrap_manager()
+void test_create_bootstrap_manager(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -166,7 +166,7 @@ void test_create_bootstrap_manager()
     KAA_TRACE_OUT(logger);
 }
 
-static kaa_access_point_t *create_access_point()
+static kaa_access_point_t *create_access_point(void)
 {
     const uint16_t MAX_CONNECTION_DATA_SIZE = 16;
 
@@ -192,7 +192,7 @@ static void destroy_access_point(kaa_access_point_t * access_point)
     }
 }
 
-void test_handle_server_sync()
+void test_handle_server_sync(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -393,7 +393,7 @@ static kaa_error_t find_bootstrap_access_point_index(kaa_transport_protocol_id_t
     return KAA_ERR_NOT_FOUND;
 }
 
-void test_bootstrap_channel()
+void test_bootstrap_channel(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_channel_manager.c
+++ b/client/client-multi/client-c/test/test_kaa_channel_manager.c
@@ -156,7 +156,7 @@ static void compare_channels(kaa_transport_channel_interface_t *actual_channel
 /**
  * UNIT TESTS
  */
-void test_create_channel_manager()
+void test_create_channel_manager(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -176,7 +176,7 @@ void test_create_channel_manager()
     kaa_channel_manager_destroy(channel_manager);
 }
 
-void test_add_channel()
+void test_add_channel(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -220,7 +220,7 @@ void test_add_channel()
     kaa_channel_manager_destroy(channel_manager);
 }
 
-void test_get_service_specific_channel()
+void test_get_service_specific_channel(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -286,7 +286,7 @@ void test_get_service_specific_channel()
     kaa_channel_manager_destroy(channel_manager);
 }
 
-void test_get_bootstrap_client_sync_size()
+void test_get_bootstrap_client_sync_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -366,7 +366,7 @@ void test_get_bootstrap_client_sync_size()
     kaa_channel_manager_destroy(channel_manager);
 }
 
-void test_get_bootstrap_client_sync_serialize()
+void test_get_bootstrap_client_sync_serialize(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_common.c
+++ b/client/client-multi/client-c/test/test_kaa_common.c
@@ -26,7 +26,7 @@
 
 static kaa_logger_t *logger = NULL;
 
-void test_profile_update()
+void test_profile_update(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_common_schema.c
+++ b/client/client-multi/client-c/test/test_kaa_common_schema.c
@@ -33,7 +33,7 @@ static kaa_logger_t *logger = NULL;
 
 
 
-static void test_string_move_create()
+static void test_string_move_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -69,7 +69,7 @@ static void test_string_move_create()
 
 
 
-static void test_string_copy_create()
+static void test_string_copy_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -90,7 +90,7 @@ static void test_string_copy_create()
 
 
 
-static void test_string_get_size()
+static void test_string_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -110,7 +110,7 @@ static void test_string_get_size()
 
 
 
-static void test_string_serialize()
+static void test_string_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -160,7 +160,7 @@ static void test_string_serialize()
 
 
 
-static void test_string_deserialize()
+static void test_string_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -192,7 +192,7 @@ static void test_string_deserialize()
 
 
 
-static void test_bytes_move_create()
+static void test_bytes_move_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -233,7 +233,7 @@ static void test_bytes_move_create()
 
 
 
-static void test_bytes_copy_create()
+static void test_bytes_copy_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -259,7 +259,7 @@ static void test_bytes_copy_create()
 
 
 
-static void test_bytes_get_size()
+static void test_bytes_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -278,7 +278,7 @@ static void test_bytes_get_size()
 
 
 
-static void test_bytes_serialize()
+static void test_bytes_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -329,7 +329,7 @@ static void test_bytes_serialize()
 
 
 
-static void test_bytes_deserialize()
+static void test_bytes_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -363,7 +363,7 @@ static void test_bytes_deserialize()
 
 
 
-static void test_fixed_move_create()
+static void test_fixed_move_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -404,7 +404,7 @@ static void test_fixed_move_create()
 
 
 
-static void test_fixed_copy_create()
+static void test_fixed_copy_create(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -430,7 +430,7 @@ static void test_fixed_copy_create()
 
 
 
-static void test_fixed_get_size()
+static void test_fixed_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -449,7 +449,7 @@ static void test_fixed_get_size()
 
 
 
-static void test_fixed_serialize()
+static void test_fixed_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -500,7 +500,7 @@ static void test_fixed_serialize()
 
 
 
-static void test_fixed_deserialize()
+static void test_fixed_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -534,7 +534,7 @@ static void test_fixed_deserialize()
 
 
 
-static void test_boolean_get_size()
+static void test_boolean_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -549,7 +549,7 @@ static void test_boolean_get_size()
 
 
 
-static void test_boolean_serialize()
+static void test_boolean_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -573,7 +573,7 @@ static void test_boolean_serialize()
 
 
 
-static void test_boolean_deserialize()
+static void test_boolean_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -599,7 +599,7 @@ static void test_boolean_deserialize()
 
 
 
-static void test_int_get_size()
+static void test_int_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -614,7 +614,7 @@ static void test_int_get_size()
 
 
 
-static void test_int_serialize()
+static void test_int_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -638,7 +638,7 @@ static void test_int_serialize()
 
 
 
-static void test_int_deserialize()
+static void test_int_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -664,7 +664,7 @@ static void test_int_deserialize()
 
 
 
-static void test_long_get_size()
+static void test_long_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -679,7 +679,7 @@ static void test_long_get_size()
 
 
 
-static void test_long_serialize()
+static void test_long_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -703,7 +703,7 @@ static void test_long_serialize()
 
 
 
-static void test_long_deserialize()
+static void test_long_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -739,7 +739,7 @@ typedef enum {
 
 
 
-static void test_enum_get_size()
+static void test_enum_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -754,7 +754,7 @@ static void test_enum_get_size()
 
 
 
-static void test_enum_serialize()
+static void test_enum_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -778,7 +778,7 @@ static void test_enum_serialize()
 
 
 
-static void test_enum_deserialize()
+static void test_enum_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -804,7 +804,7 @@ static void test_enum_deserialize()
 
 
 
-static void test_float_get_size()
+static void test_float_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -819,7 +819,7 @@ static void test_float_get_size()
 
 
 
-static void test_float_serialize()
+static void test_float_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -843,7 +843,7 @@ static void test_float_serialize()
 
 
 
-static void test_float_deserialize()
+static void test_float_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -869,7 +869,7 @@ static void test_float_deserialize()
 
 
 
-static void test_double_get_size()
+static void test_double_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -884,7 +884,7 @@ static void test_double_get_size()
 
 
 
-static void test_double_serialize()
+static void test_double_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -908,7 +908,7 @@ static void test_double_serialize()
 
 
 
-static void test_double_deserialize()
+static void test_double_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -934,12 +934,12 @@ static void test_double_deserialize()
 
 
 
-static void test_null_get_size()
+static void test_null_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
     srand(time(NULL));
-    ASSERT_EQUAL(kaa_null_get_size(NULL), 0);
+    ASSERT_EQUAL(kaa_null_get_size(), 0);
 
     ASSERT_EQUAL(kaa_null_get_size(), AVRO_NULL_SIZE);
 
@@ -948,7 +948,7 @@ static void test_null_get_size()
 
 
 
-static void test_null_serialize()
+static void test_null_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -976,7 +976,7 @@ static void test_null_serialize()
 
 
 
-static void test_null_deserialize()
+static void test_null_deserialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -994,7 +994,7 @@ static void test_null_deserialize()
 
 
 
-static void test_array_get_size()
+static void test_array_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -1028,7 +1028,7 @@ static void test_array_get_size()
 
 
 
-static void test_null_array_serialize()
+static void test_null_array_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -1049,7 +1049,7 @@ static void test_null_array_serialize()
 
 
 
-static void test_empty_array_serialize()
+static void test_empty_array_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -1072,7 +1072,7 @@ static void test_empty_array_serialize()
 
 
 
-static void test_array_serialize()
+static void test_array_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -1119,7 +1119,7 @@ static void test_array_serialize()
 
 
 
-static float *create_float()
+static float *create_float(void)
 {
     float *float_value = (float *)KAA_MALLOC(sizeof(float));
     KAA_RETURN_IF_NIL(float_value, NULL);
@@ -1131,7 +1131,7 @@ void kaa_null_destroy(void *data)
 {
 }
 
-static void test_array_deserialize_wo_ctx()
+static void test_array_deserialize_wo_ctx(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -1199,7 +1199,7 @@ static void test_array_deserialize_wo_ctx()
 
 
 
-static void test_array_deserialize_w_ctx()
+static void test_array_deserialize_w_ctx(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_configuration.c
+++ b/client/client-multi/client-c/test/test_kaa_configuration.c
@@ -67,7 +67,7 @@ static kaa_error_t on_configuration_updated(void *context, const kaa_root_config
     return KAA_ERR_NONE;
 }
 
-void test_create_request()
+void test_create_request(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -100,7 +100,7 @@ void test_create_request()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_response()
+void test_response(void)
 {
     KAA_TRACE_IN(logger);
     const size_t response_size = kaa_aligned_size_get(KAA_CONFIGURATION_DATA_LENGTH) + sizeof(uint32_t) + sizeof(uint32_t);

--- a/client/client-multi/client-c/test/test_kaa_event.c
+++ b/client/client-multi/client-c/test/test_kaa_event.c
@@ -77,7 +77,7 @@ static int test_deinit(void);
 
 
 
-void test_kaa_create_event_manager()
+void test_kaa_create_event_manager(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -112,7 +112,7 @@ static kaa_error_t event_listeners_request_failed(void *context)
     return KAA_ERR_NONE;
 }
 
-void test_kaa_event_listeners_serialize_request()
+void test_kaa_event_listeners_serialize_request(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -174,7 +174,7 @@ void test_kaa_event_listeners_serialize_request()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaa_event_listeners_handle_sync()
+void test_kaa_event_listeners_handle_sync(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -224,7 +224,7 @@ void test_kaa_event_listeners_handle_sync()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaa_event_sync_get_size()
+void test_kaa_event_sync_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -351,7 +351,7 @@ static kaa_error_t serialize_event(kaa_platform_message_writer_t *writer
 
 
 
-void test_event_sync_serialize()
+void test_event_sync_serialize(void)
 {
     test_deinit();
     test_init();
@@ -498,7 +498,7 @@ static size_t event_get_size(const char *fqn
     return size;
 }
 
-void test_event_blocks()
+void test_event_blocks(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -560,7 +560,7 @@ void test_event_blocks()
     KAA_TRACE_OUT(logger);
 }
 
-void test_kaa_server_sync_with_event_callbacks()
+void test_kaa_server_sync_with_event_callbacks(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_log.c
+++ b/client/client-multi/client-c/test/test_kaa_log.c
@@ -213,7 +213,7 @@ static void destroy_log_record(void *record_p)
     }
 }
 
-mock_storage_context_t *create_mock_storage()
+mock_storage_context_t *create_mock_storage(void)
 {
     mock_storage_context_t *storage = (mock_storage_context_t *)KAA_CALLOC(1, sizeof(mock_storage_context_t));
     KAA_RETURN_IF_NIL(storage, NULL);
@@ -233,7 +233,7 @@ kaa_error_t ext_log_storage_destroy(void *context)
 
 
 
-void test_create_request()
+void test_create_request(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -304,7 +304,7 @@ void test_create_request()
 
 
 
-void test_response()
+void test_response(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -367,7 +367,7 @@ void test_response()
 
 
 
-void test_timeout()
+void test_timeout(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -417,7 +417,7 @@ void test_timeout()
     KAA_TRACE_OUT(logger);
 }
 
-void test_decline_timeout()
+void test_decline_timeout(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_notification.c
+++ b/client/client-multi/client-c/test/test_kaa_notification.c
@@ -74,7 +74,7 @@ char *allocator (void *context, size_t size)
 char *buffer = NULL;
 size_t buffer_size = 0;
 
-int test_init()
+int test_init(void)
 {
     err = KAA_ERR_NONE;
 
@@ -98,7 +98,7 @@ int test_init()
     return 0;
 }
 
-int test_deinit()
+int test_deinit(void)
 {
     if (context) {
         kaa_deinit(context);
@@ -110,7 +110,7 @@ int test_deinit()
     return 0;
 }
 
-void test_deserializing()
+void test_deserializing(void)
 {
     KAA_TRACE_IN(context->logger);
     kaa_notification_t *notification = kaa_notification_notification_create();
@@ -191,7 +191,7 @@ void test_deserializing()
     KAA_TRACE_OUT(context->logger);
 }
 
-void test_notification_listeners_adding_and_removing()
+void test_notification_listeners_adding_and_removing(void)
 {
     KAA_TRACE_IN(context->logger);
     err = kaa_add_notification_listener(context->notification_manager, &listener, &id);
@@ -239,7 +239,7 @@ void test_notification_listeners_adding_and_removing()
     KAA_TRACE_OUT(context->logger);
 }
 
-void test_topic_list_listeners_adding_and_removing()
+void test_topic_list_listeners_adding_and_removing(void)
 {
     KAA_TRACE_IN(context->logger);
     err = kaa_get_topics(context->notification_manager, &topics);
@@ -266,7 +266,7 @@ void test_topic_list_listeners_adding_and_removing()
     KAA_TRACE_OUT(context->logger);
 }
 
-void test_retrieving_topic_list()
+void test_retrieving_topic_list(void)
 {
     KAA_TRACE_IN(context->logger);
     err = kaa_get_topics(context->notification_manager, &topics);
@@ -278,7 +278,7 @@ void test_retrieving_topic_list()
     KAA_TRACE_OUT(context->logger);
 }
 
-void test_serializing()
+void test_serializing(void)
 {
     KAA_TRACE_IN(context->logger);
 
@@ -299,7 +299,7 @@ void test_serializing()
     KAA_TRACE_OUT(context->logger);
 }
 
-void test_subscriptions()
+void test_subscriptions(void)
 {
     KAA_TRACE_IN(context->logger);
 

--- a/client/client-multi/client-c/test/test_kaa_profile.c
+++ b/client/client-multi/client-c/test/test_kaa_profile.c
@@ -89,7 +89,7 @@ void kaa_get_endpoint_public_key(char **buffer, size_t *buffer_size, bool *needs
 
 
 
-void test_profile_update()
+void test_profile_update(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -124,7 +124,7 @@ void test_profile_update()
     profile2->destroy(profile2);
 }
 
-void test_profile_sync_get_size()
+void test_profile_sync_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -176,7 +176,7 @@ void test_profile_sync_get_size()
     profile->destroy(profile);
 }
 
-void test_profile_sync_serialize()
+void test_profile_sync_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -261,7 +261,7 @@ void test_profile_sync_serialize()
     kaa_platform_message_writer_destroy(manual_writer);
 }
 
-void test_profile_handle_sync()
+void test_profile_handle_sync(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_status.c
+++ b/client/client-multi/client-c/test/test_kaa_status.c
@@ -89,7 +89,7 @@ void ext_get_endpoint_public_key(char **buffer, size_t *buffer_size, bool *needs
     *needs_deallocation = false;
 }
 
-void test_create_status()
+void test_create_status(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -102,7 +102,7 @@ void test_create_status()
     kaa_status_destroy(status);
 }
 
-void test_status_persistense()
+void test_status_persistense(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_kaa_user.c
+++ b/client/client-multi/client-c/test/test_kaa_user.c
@@ -104,7 +104,7 @@ static kaa_error_t on_attach_failed(void *context, user_verifier_error_code_t er
     return KAA_ERR_NONE;
 }
 
-void test_specified_user_verifier()
+void test_specified_user_verifier(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -160,7 +160,7 @@ void test_specified_user_verifier()
     KAA_TRACE_OUT(logger);
 }
 
-void test_success_response()
+void test_success_response(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -192,7 +192,7 @@ void test_success_response()
     KAA_TRACE_OUT(logger);
 }
 
-void test_failed_response()
+void test_failed_response(void)
 {
     KAA_TRACE_IN(logger);
 

--- a/client/client-multi/client-c/test/test_meta_extension.c
+++ b/client/client-multi/client-c/test/test_meta_extension.c
@@ -52,7 +52,7 @@ static kaa_logger_t *logger = NULL;
 static kaa_status_t *status = NULL;
 
 
-void test_meta_extension_get_size_failed()
+void test_meta_extension_get_size_failed(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -60,7 +60,7 @@ void test_meta_extension_get_size_failed()
     ASSERT_NOT_EQUAL(error_code, KAA_ERR_NONE);
 }
 
-void test_meta_extension_get_size()
+void test_meta_extension_get_size(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -77,7 +77,7 @@ void test_meta_extension_get_size()
     ASSERT_EQUAL(expected_meta_extension_size, meta_extension_size);
 }
 
-void test_meta_extension_serialize_failed()
+void test_meta_extension_serialize_failed(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -98,7 +98,7 @@ void test_meta_extension_serialize_failed()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_meta_extension_serialize()
+void test_meta_extension_serialize(void)
 {
     KAA_TRACE_IN(logger);
 
@@ -180,7 +180,7 @@ void test_meta_extension_serialize()
 
 
 
-int test_init()
+int test_init(void)
 {
     kaa_error_t error = kaa_log_create(&logger, KAA_MAX_LOG_MESSAGE_LENGTH, KAA_MAX_LOG_LEVEL, NULL);
     if (error || !logger) {
@@ -195,7 +195,7 @@ int test_init()
     return 0;
 }
 
-int test_deinit()
+int test_deinit(void)
 {
     kaa_status_destroy(status);
     kaa_log_destroy(logger);

--- a/client/client-multi/client-c/test/test_platform_protocol.c
+++ b/client/client-multi/client-c/test/test_platform_protocol.c
@@ -84,7 +84,7 @@ void test_empty_log_collector_extension_count(void)
     KAA_LOG_DEBUG(kaa_context->logger, KAA_ERR_NONE, "count of extensions is %d, expected 1", count_of_extensions);
     ASSERT_EQUAL(count_of_extensions, 1);
 }
-int test_init()
+int test_init(void)
 {
     kaa_error_t error_code = kaa_init(&kaa_context);
     if (error_code) {
@@ -93,7 +93,7 @@ int test_init()
 	return KAA_ERR_NONE;
 }
 
-int test_deinit()
+int test_deinit(void)
 {
     kaa_deinit(kaa_context);
     KAA_FREE(buffer);

--- a/client/client-multi/client-c/test/test_platform_utils.c
+++ b/client/client-multi/client-c/test/test_platform_utils.c
@@ -25,14 +25,14 @@
 #include "kaa_platform_utils.h"
 #include "utilities/kaa_mem.h"
 
-void test_get_aligned_size()
+void test_get_aligned_size(void)
 {
     ASSERT_EQUAL(KAA_ALIGNMENT, kaa_aligned_size_get(KAA_ALIGNMENT));
     ASSERT_EQUAL(KAA_ALIGNMENT, kaa_aligned_size_get(KAA_ALIGNMENT - 1));
     ASSERT_EQUAL(2 * KAA_ALIGNMENT, kaa_aligned_size_get(KAA_ALIGNMENT + 1));
 }
 
-void test_create_destroy_writer()
+void test_create_destroy_writer(void)
 {
     kaa_platform_message_writer_t *writer = NULL;
     char buffer[16];
@@ -60,7 +60,7 @@ void test_create_destroy_writer()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_write()
+void test_write(void)
 {
     kaa_error_t error_code = KAA_ERR_NONE;
     char buffer[16];
@@ -83,7 +83,7 @@ void test_write()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_aligned_write()
+void test_aligned_write(void)
 {
     kaa_error_t error_code = KAA_ERR_NONE;
     char buffer[3 * KAA_ALIGNMENT];
@@ -124,7 +124,7 @@ void test_aligned_write()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_write_buffer_overflow()
+void test_write_buffer_overflow(void)
 {
     kaa_error_t error_code = KAA_ERR_NONE;
     char buffer[2 * KAA_ALIGNMENT];
@@ -147,7 +147,7 @@ void test_write_buffer_overflow()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_write_protocol_message_header()
+void test_write_protocol_message_header(void)
 {
     kaa_error_t error_code = KAA_ERR_NONE;
     char buffer[KAA_PROTOCOL_ID_SIZE + KAA_PROTOCOL_VERSION_SIZE];
@@ -170,7 +170,7 @@ void test_write_protocol_message_header()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_write_extension_header()
+void test_write_extension_header(void)
 {
     kaa_error_t error_code = KAA_ERR_NONE;
     char buffer[KAA_EXTENSION_HEADER_SIZE];
@@ -195,7 +195,7 @@ void test_write_extension_header()
     kaa_platform_message_writer_destroy(writer);
 }
 
-void test_create_destroy_reader()
+void test_create_destroy_reader(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
     char buffer[16];
@@ -223,7 +223,7 @@ void test_create_destroy_reader()
     kaa_platform_message_reader_destroy(reader);
 }
 
-void test_read()
+void test_read(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
     char write_buffer[16];
@@ -251,7 +251,7 @@ void test_read()
     kaa_platform_message_reader_destroy(reader);
 }
 
-void test_read_aligned()
+void test_read_aligned(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
     char write_buffer[3 * KAA_ALIGNMENT];
@@ -274,7 +274,7 @@ void test_read_aligned()
     kaa_platform_message_reader_destroy(reader);
 }
 
-void test_read_eof()
+void test_read_eof(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
     char write_buffer[2 * KAA_ALIGNMENT];
@@ -296,7 +296,7 @@ void test_read_eof()
     kaa_platform_message_reader_destroy(reader);
 }
 
-void test_read_protocol_message_header()
+void test_read_protocol_message_header(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
 
@@ -324,7 +324,7 @@ void test_read_protocol_message_header()
     kaa_platform_message_reader_destroy(reader);
 }
 
-void test_read_extension_header()
+void test_read_extension_header(void)
 {
     kaa_platform_message_reader_t *reader = NULL;
 

--- a/client/client-multi/client-c/test/utilities/test_kaa_reallocation.c
+++ b/client/client-multi/client-c/test/utilities/test_kaa_reallocation.c
@@ -27,7 +27,7 @@
 static kaa_logger_t *logger = NULL;
 
 
-void test_reallocation()
+void test_reallocation(void)
 {
     KAA_TRACE_IN(logger);
 


### PR DESCRIPTION
There is a difference between `void f()` and `void f(void)` in C.
