### PR TITLE
KAA-705 When security keys contain junk data endpoint is not able to recover

### DIFF
--- a/client/client-multi/client-cpp/impl/security/KeyUtils.cpp
+++ b/client/client-multi/client-cpp/impl/security/KeyUtils.cpp
@@ -49,8 +49,7 @@ bool KeyUtils::checkKeyPair(const KeyPair &keys)
         result = ppriv->check_key(rng_, strongCheck);
 
         return result;
-    }
-    catch(...) {
+    } catch(...) {
         // Any exceptional situation signals that keys are not valid
         return false;
     }

--- a/client/client-multi/client-cpp/impl/security/KeyUtils.cpp
+++ b/client/client-multi/client-cpp/impl/security/KeyUtils.cpp
@@ -32,6 +32,30 @@ SessionKey KeyUtils::generateSessionKey(std::size_t length)
     return Botan::SymmetricKey(rng_, length);
 }
 
+bool KeyUtils::checkKeyPair(const KeyPair &keys)
+{
+    try {
+        auto &pub = keys.getPublicKey();
+        std::unique_ptr<Botan::Public_Key> ppub{Botan::X509::load_key(pub)};
+        bool strongCheck = true;
+        bool result = ppub->check_key(rng_, strongCheck);
+
+        if (!result)
+            return result;
+
+        auto &priv = keys.getPrivateKey();
+        Botan::DataSource_Memory src(priv);
+        std::unique_ptr<Botan::Private_Key> ppriv{Botan::PKCS8::load_key(src, rng_)};
+        result = ppriv->check_key(rng_, strongCheck);
+
+        return result;
+    }
+    catch(...) {
+        // Any exceptional situation signals that keys are not valid
+        return false;
+    }
+}
+
 void KeyUtils::readFile(const std::string& fileName, boost::scoped_array<char>& buf, std::size_t& len)
 {
     std::ifstream file(fileName, std::ifstream::binary);

--- a/client/client-multi/client-cpp/kaa/security/KeyUtils.hpp
+++ b/client/client-multi/client-cpp/kaa/security/KeyUtils.hpp
@@ -45,6 +45,15 @@ public:
      */
     SessionKey generateSessionKey(std::size_t length);
 
+    /**
+     * Checks consistency of the key pair.
+     *
+     * @param[in] keys     Target key pair
+     * @retval    true     Keys are valid
+     * @retval    false    Keys are invalid
+     */
+    bool checkKeyPair(const KeyPair &keys);
+
     static PublicKey loadPublicKey(const std::string& fileName);
 
     static PrivateKey loadPrivateKey(const std::string& fileName);

--- a/client/client-multi/client-cpp/test/impl/security/KeyUtilsTest.cpp
+++ b/client/client-multi/client-cpp/test/impl/security/KeyUtilsTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <boost/test/unit_test.hpp>
-
+#include <fstream>
 #include <cstdio>
 #include <cstring>
 
@@ -27,28 +27,95 @@
 
 namespace kaa {
 
+struct KeyUtilsFixture
+{
+    KeyUtilsFixture()
+        :newPublicKeyPath{RESOURCE_DIR"/key.new_public"}
+        ,newPrivateKeyPath{RESOURCE_DIR"/key.new_private"}
+        ,keyUtils{}
+        ,generatedKeyPair{keyUtils.generateKeyPair(keyLength)}
+    {
+
+    }
+
+    ~KeyUtilsFixture()
+    {
+        std::remove(newPublicKeyPath.c_str());
+        std::remove(newPrivateKeyPath.c_str());
+    }
+
+    void saveKeyPairToFiles()
+    {
+        KeyUtils::saveKeyPair(generatedKeyPair, newPublicKeyPath, newPrivateKeyPath);
+    }
+
+    KeyPair loadKeyPairsFromFiles()
+    {
+        return KeyUtils::loadKeyPair(newPublicKeyPath, newPrivateKeyPath);
+    }
+
+    static constexpr size_t keyLength = 2048;
+
+    const std::string newPublicKeyPath;
+    const std::string newPrivateKeyPath;
+
+    KeyUtils keyUtils;
+    KeyPair  generatedKeyPair;
+};
+
 BOOST_AUTO_TEST_SUITE(KeyUtilsTestSuite)
 
-BOOST_AUTO_TEST_CASE(SaveLoadKeyPairTest)
+BOOST_FIXTURE_TEST_CASE(GeneratedKeysAreValid, KeyUtilsFixture)
 {
-    const size_t keyLength = 2048;
-    const std::string newPublicKeyPath = RESOURCE_DIR"/key.new_public";
-    const std::string newPrivateKeyPath = RESOURCE_DIR"/key.new_private";
+    BOOST_CHECK(keyUtils.checkKeyPair(generatedKeyPair));
+}
 
-    auto generatedKeyPair = KeyUtils().generateKeyPair(keyLength);
+BOOST_FIXTURE_TEST_CASE(CorruptedPrivateKeyIsNotValid, KeyUtilsFixture)
+{
+    saveKeyPairToFiles();
 
-    KeyUtils::saveKeyPair(generatedKeyPair, newPublicKeyPath, newPrivateKeyPath);
-    auto loadedKeyPair = KeyUtils::loadKeyPair(newPublicKeyPath, newPrivateKeyPath);
+    std::fstream priv(newPrivateKeyPath.c_str(),
+                      std::ios::out | std::ios::in);
+
+    // Corrupt private key somewhere in the middle of the file
+    priv.seekp(50);
+    priv << "TheAnswerToTheUltimateQuestionOfLifeTheUniverseAndEverythingIs42\n";
+    priv.close();
+
+    auto loadedKeyPair = loadKeyPairsFromFiles();
+    BOOST_CHECK(!keyUtils.checkKeyPair(loadedKeyPair));
+}
+
+BOOST_FIXTURE_TEST_CASE(CorruptedPublicKeyIsNotValid, KeyUtilsFixture)
+{
+    saveKeyPairToFiles();
+
+    std::fstream pub(newPublicKeyPath.c_str(),
+                     std::ios::out | std::ios::in);
+
+    // Corrupt public key somewhere in the middle of the file
+    pub.seekp(20);
+    pub << 42;
+    pub.close();
+
+    auto loadedKeyPair = loadKeyPairsFromFiles();
+    BOOST_CHECK(!keyUtils.checkKeyPair(loadedKeyPair));
+}
+
+BOOST_FIXTURE_TEST_CASE(SaveLoadKeyPairTest, KeyUtilsFixture)
+{
+    saveKeyPairToFiles();
+    auto loadedKeyPair = loadKeyPairsFromFiles();
 
     BOOST_CHECK_MESSAGE(generatedKeyPair.getPublicKey() == loadedKeyPair.getPublicKey()
                                     , "Loaded and saved public key don't match");
     BOOST_CHECK_MESSAGE(generatedKeyPair.getPrivateKey() == loadedKeyPair.getPrivateKey()
                                     , "Loaded and saved private key don't match");
 
-    std::remove(newPublicKeyPath.c_str());
-    std::remove(newPrivateKeyPath.c_str());
+    BOOST_CHECK(keyUtils.checkKeyPair(loadedKeyPair));
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
 
 }


### PR DESCRIPTION
New pair will be generated if keys storage is corrupted.
