### PR TITLE
Bug/KAA-856

### DIFF
--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -73,6 +73,11 @@ private:
     void captureStack(std::stringstream& ss)  {
          void *trace[16];
          int i, trace_size = 0;
+
+#if KAA_MAX_LOG_LEVEL>=5
+         return;
+#endif
+
 #ifdef _WIN32
          SYMBOL_INFO  * symbol;
          HANDLE process;

--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -74,7 +74,7 @@ private:
          void *trace[16];
          int i, trace_size = 0;
 
-#if KAA_MAX_LOG_LEVEL>=5
+#if KAA_MAX_LOG_LEVEL<5
          return;
 #endif
 

--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -21,7 +21,7 @@
 #include <exception>
 #include <sstream>
 
-#if KAA_MAX_LOG_LEVEL>=5
+#ifndef NDEBUG
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -32,7 +32,7 @@
 #else
 #include <execinfo.h>
 #endif
-#endif // KAA_MAX_LOG_LEVEL>=5
+#endif // NDEBUG
 
 namespace kaa {
 
@@ -76,7 +76,7 @@ private:
          void *trace[16];
          int i, trace_size = 0;
 
-#if KAA_MAX_LOG_LEVEL>=5
+#ifndef NDEBUG
 
 #ifdef _WIN32
          SYMBOL_INFO  * symbol;
@@ -104,7 +104,7 @@ private:
 #ifdef _WIN32
          free( symbol );
 #endif
-#endif // KAA_MAX_LOG_LEVEL>=5
+#endif // NDEBUG
      }
 };
 

--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -21,6 +21,7 @@
 #include <exception>
 #include <sstream>
 
+#if KAA_MAX_LOG_LEVEL>=5
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -31,6 +32,7 @@
 #else
 #include <execinfo.h>
 #endif
+#endif // KAA_MAX_LOG_LEVEL>=5
 
 namespace kaa {
 
@@ -74,9 +76,7 @@ private:
          void *trace[16];
          int i, trace_size = 0;
 
-#if KAA_MAX_LOG_LEVEL<5
-         return;
-#endif
+#if KAA_MAX_LOG_LEVEL>=5
 
 #ifdef _WIN32
          SYMBOL_INFO  * symbol;
@@ -104,6 +104,7 @@ private:
 #ifdef _WIN32
          free( symbol );
 #endif
+#endif // KAA_MAX_LOG_LEVEL>=5
      }
 };
 

--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -73,11 +73,9 @@ private:
     std::string message_;
 
     void captureStack(std::stringstream& ss)  {
+#ifndef NDEBUG
          void *trace[16];
          int i, trace_size = 0;
-
-#ifndef NDEBUG
-
 #ifdef _WIN32
          SYMBOL_INFO  * symbol;
          HANDLE process;
@@ -104,6 +102,8 @@ private:
 #ifdef _WIN32
          free( symbol );
 #endif
+#else
+         static_cast<void>(ss);
 #endif // NDEBUG
      }
 };


### PR DESCRIPTION
[C++ SDK] Display stacktrace in KaaException only if debug build is enabled
