### PR TITLE
KAA-921: set bucket timestamp before triggering delivery callback

### DIFF
--- a/client/client-multi/client-objective-c/Kaa.xcodeproj/project.pbxproj
+++ b/client/client-multi/client-objective-c/Kaa.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		B8B4CDC11B8213C0007FE20D /* KaaClientProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = B8B4CDBF1B8213C0007FE20D /* KaaClientProperties.h */; };
 		B8B4CDC21B8213C0007FE20D /* KaaClientProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = B8B4CDC01B8213C0007FE20D /* KaaClientProperties.m */; };
 		B8C10A151BC2BBBF001A2236 /* KaaClientPropertiesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B8C10A131BC2BBBF001A2236 /* KaaClientPropertiesTest.m */; };
+		B8C794881C9337B7009469EB /* LogDeliveryCallbackTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B8C794871C9337B7009469EB /* LogDeliveryCallbackTests.m */; };
 		B8CCBD861C4664D800C26F0B /* io.h in Headers */ = {isa = PBXBuildFile; fileRef = B8CCBD601C4664D800C26F0B /* io.h */; };
 		B8CCBD871C4664D800C26F0B /* platform.h in Headers */ = {isa = PBXBuildFile; fileRef = B8CCBD611C4664D800C26F0B /* platform.h */; };
 		B8CCBD881C4664D800C26F0B /* avro_private.h in Headers */ = {isa = PBXBuildFile; fileRef = B8CCBD621C4664D800C26F0B /* avro_private.h */; };
@@ -766,6 +767,7 @@
 		B8B4CDBF1B8213C0007FE20D /* KaaClientProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KaaClientProperties.h; sourceTree = "<group>"; };
 		B8B4CDC01B8213C0007FE20D /* KaaClientProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KaaClientProperties.m; sourceTree = "<group>"; };
 		B8C10A131BC2BBBF001A2236 /* KaaClientPropertiesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KaaClientPropertiesTest.m; sourceTree = "<group>"; };
+		B8C794871C9337B7009469EB /* LogDeliveryCallbackTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LogDeliveryCallbackTests.m; sourceTree = "<group>"; };
 		B8CCBD601C4664D800C26F0B /* io.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = io.h; sourceTree = "<group>"; };
 		B8CCBD611C4664D800C26F0B /* platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platform.h; sourceTree = "<group>"; };
 		B8CCBD621C4664D800C26F0B /* avro_private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = avro_private.h; sourceTree = "<group>"; };
@@ -1702,6 +1704,7 @@
 				B8CCC0361C467EAB00C26F0B /* memory */,
 				B8CCC0391C467EAB00C26F0B /* strategies */,
 				B85B18F41C92E9CA002467B1 /* AbstractLogCollectorTests.m */,
+				B8C794871C9337B7009469EB /* LogDeliveryCallbackTests.m */,
 			);
 			path = logging;
 			sourceTree = "<group>";
@@ -2250,6 +2253,7 @@
 				B8CCC04B1C467EAB00C26F0B /* DefaultBootstrapChannelTest.m in Sources */,
 				B8CCC0671C467EAB00C26F0B /* StorageSizeLogUploadStrategyTest.m in Sources */,
 				B8CCC06A1C467EAB00C26F0B /* DefaultProfileManagerTest.m in Sources */,
+				B8C794881C9337B7009469EB /* LogDeliveryCallbackTests.m in Sources */,
 				B8CCC0571C467EAB00C26F0B /* DefaultProfileTransportTest.m in Sources */,
 				B8CCC0681C467EAB00C26F0B /* StorageSizeWithTimeLimitLogUploadStrategyTest.m in Sources */,
 				B8CCC0691C467EAB00C26F0B /* DefaultNotificationManagerTest.m in Sources */,

--- a/client/client-multi/client-objective-c/Kaa/log/AbstractLogCollector.m
+++ b/client/client-multi/client-objective-c/Kaa/log/AbstractLogCollector.m
@@ -148,15 +148,16 @@
 
                     if (status.result == SYNC_RESPONSE_RESULT_TYPE_SUCCESS) {
                         [self.storage removeBucketWithId:status.requestId];
+                        
+                        [[self.executorContext getCallbackExecutor] addOperationWithBlock:^{
+                            [weakSelf notifyOnSuccessDeliveryRunnersWithBucketInfo:bucketInfo];
+                        }];
+                        
                         if (self.logDeliveryDelegate) {
                             [[self.executorContext getCallbackExecutor] addOperationWithBlock:^{
                                 [weakSelf.logDeliveryDelegate onLogDeliverySuccessWithBucketInfo:bucketInfo];
                             }];
                         }
-                        
-                        [[self.executorContext getCallbackExecutor] addOperationWithBlock:^{
-                            [weakSelf notifyOnSuccessDeliveryRunnersWithBucketInfo:bucketInfo];
-                        }];
 
                     } else {
                         [self.storage rollbackBucketWithId:status.requestId];

--- a/client/client-multi/client-objective-c/KaaTests/logging/DefaultLogUploadStrategyTest.m
+++ b/client/client-multi/client-objective-c/KaaTests/logging/DefaultLogUploadStrategyTest.m
@@ -30,11 +30,13 @@
 #import "MemLogStorage.h"
 #import "DefaultLogCollector.h"
 
-@interface AbstractLogCollector (NoTimeoutLogCollector)
+@interface NoTimeoutLogCollector : DefaultLogCollector
+
+- (void)checkDeliveryTimeoutForBucketId:(int32_t)bucketId;
 
 @end
 
-@implementation AbstractLogCollector (NoTimeoutLogCollector)
+@implementation NoTimeoutLogCollector
 
 - (void)checkDeliveryTimeoutForBucketId:(int32_t)bucketId {
     //NOTE: method stub to avoid removing buckets from timeout tracking
@@ -153,7 +155,7 @@
     [given([executorContext getApiExecutor]) willReturn:apiExecutor];
     [given([executorContext getSheduledExecutor]) willReturn:schedulerQueue];
     
-    AbstractLogCollector *logCollector = [[DefaultLogCollector alloc] initWithTransport:logTransport executorContext:executorContext channelManager:channelManager failoverManager:failoverManager];
+    AbstractLogCollector *logCollector = [[NoTimeoutLogCollector alloc] initWithTransport:logTransport executorContext:executorContext channelManager:channelManager failoverManager:failoverManager];
     DefaultLogUploadStrategy *strategy = mock([DefaultLogUploadStrategy class]);
     [given([strategy getMaxParallelUploads]) willReturnLong:maxParallelUploads];
     [logCollector setValue:strategy forKey:@"strategy"];
@@ -197,7 +199,7 @@
     [given([executorContext getApiExecutor]) willReturn:apiExecutor];
     [given([executorContext getSheduledExecutor]) willReturn:schedulerQueue];
 
-    AbstractLogCollector *logCollector = [[DefaultLogCollector alloc] initWithTransport:logTransport executorContext:executorContext channelManager:channelManager failoverManager:failoverManager];
+    AbstractLogCollector *logCollector = [[NoTimeoutLogCollector alloc] initWithTransport:logTransport executorContext:executorContext channelManager:channelManager failoverManager:failoverManager];
     DefaultLogUploadStrategy *strategy = mock([DefaultLogUploadStrategy class]);
     [given([strategy isUploadNeededForStorageStatus:anything()]) willReturnInt:LOG_UPLOAD_STRATEGY_DECISION_UPLOAD];
     [given([strategy getMaxParallelUploads]) willReturnLong:maxParallelUploads];

--- a/client/client-multi/client-objective-c/KaaTests/logging/LogDeliveryCallbackTests.m
+++ b/client/client-multi/client-objective-c/KaaTests/logging/LogDeliveryCallbackTests.m
@@ -1,0 +1,155 @@
+/**
+ *  Copyright 2014-2016 CyberVision, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
+
+#define MOCKITO_SHORTHAND
+#import <OCMockito/OCMockito.h>
+
+#import "DefaultLogUploadStrategy.h"
+#import "AbstractLogCollector.h"
+#import "EndpointGen.h"
+#import "LogCollector.h"
+#import "ExecutorContext.h"
+#import "MemLogStorage.h"
+#import "DefaultLogCollector.h"
+#import "BucketInfo.h"
+#import "TestsHelper.h"
+
+@interface LogDeliveryDelegateImpl : NSObject <LogDeliveryDelegate>
+
+@property (nonatomic) double scheduledBucketTimestamp;
+@property (nonatomic) double bucketDeliveryDuration;
+
+@end
+
+@implementation LogDeliveryDelegateImpl
+
+- (void)onLogDeliverySuccessWithBucketInfo:(BucketInfo *)bucketInfo {
+    self.scheduledBucketTimestamp = bucketInfo.scheduledBucketTimestamp;
+    self.bucketDeliveryDuration = bucketInfo.bucketDeliveryDuration;
+}
+
+- (void)onLogDeliveryFailureWithBucketInfo:(BucketInfo *)bucketInfo {
+    [NSException raise:NSInternalInconsistencyException format:@"Method is not expected to be called!"];
+}
+
+- (void)onLogDeliveryTimeoutWithBucketInfo:(BucketInfo *)bucketInfo {
+    [NSException raise:NSInternalInconsistencyException format:@"Method is not expected to be called!"];
+}
+
+@end
+
+@interface LogDeliveryCallbackTests : XCTestCase
+
+@property (nonatomic, strong) id<ExecutorContext> executorContext;
+@property (nonatomic, strong) id<LogTransport> logTransport;
+@property (nonatomic, strong) id<KaaChannelManager> channelManager;
+@property (nonatomic, strong) id<FailoverManager> failoverManager;
+@property (nonatomic, strong) id<LogUploadStrategy> strategy;
+@property (nonatomic, strong) AbstractLogCollector *logCollector;
+
+@end
+
+@implementation LogDeliveryCallbackTests
+
+- (void)setUp {
+    [super setUp];
+    self.executorContext = mockProtocol(@protocol(ExecutorContext));
+    self.logTransport = mockProtocol(@protocol(LogTransport));
+    self.channelManager = mockProtocol(@protocol(KaaChannelManager));
+    self.failoverManager = mockProtocol(@protocol(FailoverManager));
+    self.logCollector = [[AbstractLogCollector alloc] initWithTransport:self.logTransport
+                                                        executorContext:self.executorContext
+                                                         channelManager:self.channelManager
+                                                        failoverManager:self.failoverManager];
+    
+    self.strategy = mockProtocol(@protocol(LogUploadStrategy));
+    [given([self.strategy getMaxParallelUploads]) willReturn:@(10)];
+    [self.logCollector setValue:self.strategy forKey:@"strategy"];
+}
+
+- (void)testSimpleCallbacksTriggering {
+    
+    id<LogDeliveryDelegate> delegate = mockProtocol(@protocol(LogDeliveryDelegate));
+    [self.logCollector setLogDeliveryDelegate:delegate];
+    
+    [given([self.strategy getTimeout]) willReturn:@(0)];
+    
+    NSOperationQueue *callbackQueue = [[NSOperationQueue alloc] init];
+    dispatch_queue_t schedulerQueue = dispatch_queue_create("scheduledExecutor", 0);
+    [given([self.executorContext getCallbackExecutor]) willReturn:callbackQueue];
+    [given([self.executorContext getSheduledExecutor]) willReturn:schedulerQueue];
+    
+    LogDeliveryStatus *status = [[LogDeliveryStatus alloc] init];
+    status.requestId = 42;
+    status.result = SYNC_RESPONSE_RESULT_TYPE_SUCCESS;
+    LogSyncResponse *response = [[LogSyncResponse alloc] initWithDeliveryStatuses:[KAAUnion unionWithBranch:KAA_UNION_ARRAY_LOG_DELIVERY_STATUS_OR_NULL_BRANCH_0 data:[NSArray arrayWithObject:status]]];
+    
+    BucketInfo *bucketInfo = [[BucketInfo alloc] initWithBucketId:42 logCount:1];
+    self.logCollector.bucketInfoDictionary[@(bucketInfo.bucketId)] = bucketInfo;
+    
+    [self.logCollector onLogResponse:response];
+    [verifyCount(delegate, times(1)) onLogDeliverySuccessWithBucketInfo:bucketInfo];
+    
+
+    status.result = SYNC_RESPONSE_RESULT_TYPE_FAILURE;
+    self.logCollector.bucketInfoDictionary[@(bucketInfo.bucketId)] = bucketInfo;
+    
+    [self.logCollector onLogResponse:response];
+    [verifyCount(delegate, times(1)) onLogDeliveryFailureWithBucketInfo:bucketInfo];
+    
+    
+    id<LogStorage> storage = mockProtocol(@protocol(LogStorage));
+    LogRecord *record = [[LogRecord alloc] initWithData:[NSMutableData data]];
+    LogBucket *logBucket = [[LogBucket alloc] initWithBucketId:42 records:@[record]];
+    [given([storage getNextBucket]) willReturn:logBucket];
+    [self.logCollector setStorage:storage];
+    self.logCollector.bucketInfoDictionary[@(bucketInfo.bucketId)] = bucketInfo;
+
+    LogSyncRequest *request = mock([LogSyncRequest class]);
+    [self.logCollector fillSyncRequest:request];
+    [NSThread sleepForTimeInterval:0.5];
+    [verifyCount(delegate, times(1)) onLogDeliveryTimeoutWithBucketInfo:bucketInfo];
+}
+
+- (void)testIfBucketInfoIsTimestamped {
+    LogDeliveryDelegateImpl *delegate = [[LogDeliveryDelegateImpl alloc] init];
+    [self.logCollector setLogDeliveryDelegate:delegate];
+    
+    NSOperationQueue *executor = [[NSOperationQueue alloc] init];
+    [given([self.executorContext getCallbackExecutor]) willReturn:executor];
+    
+    LogDeliveryStatus *status = [[LogDeliveryStatus alloc] init];
+    status.requestId = 42;
+    status.result = SYNC_RESPONSE_RESULT_TYPE_SUCCESS;
+    LogSyncResponse *response = [[LogSyncResponse alloc] initWithDeliveryStatuses:[KAAUnion unionWithBranch:KAA_UNION_ARRAY_LOG_DELIVERY_STATUS_OR_NULL_BRANCH_0 data:[NSArray arrayWithObject:status]]];
+    
+    BucketInfo *bucketInfo = [[BucketInfo alloc] initWithBucketId:42 logCount:1];
+    self.logCollector.bucketInfoDictionary[@(bucketInfo.bucketId)] = bucketInfo;
+    
+    [self.logCollector addDeliveryRunner:[[BucketRunner alloc] init] bucketInfo:bucketInfo];
+    
+    [self.logCollector onLogResponse:response];
+    
+    XCTAssertNotEqual(delegate.scheduledBucketTimestamp, 0);
+    XCTAssertNotEqual(delegate.bucketDeliveryDuration, 0);
+}
+
+@end


### PR DESCRIPTION
Added tests for log delivery callbacks as well as for correct timestamping.
