### PR TITLE
KAA-820 Stop build script when error occurs

### DIFF
--- a/client/client-multi/client-c/build.sh
+++ b/client/client-multi/client-c/build.sh
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #
 
+# Exist immediately if error occurs
+set -e
 
 RUN_DIR=`pwd`
 
@@ -32,7 +34,6 @@ DEBUG_ENABLED=1
 UNITTESTS_COMPILE=0
 MAX_LOG_LEVEL=6
 COLLECT_COVERAGE=0
-
 function prepare_build {
     mkdir -p build;
     cd build;
@@ -72,37 +73,37 @@ function execute_tests {
         echo -e "\nTESTS WERE SUCCESSFULLY PASSED\n"
     fi
     cd ..
-    
+
 }
 
 function check_installed_software {
-    RATS_VERSION="$(rats -h)"
-    if [[ $RATS_VERSION = RATS* ]] 
+    if [[ "$(rats -h)" = RATS* ]]
     then
         RATS_INSTALLED=1
     else
+        echo "Rats is not installed, skipping..."
         RATS_INSTALLED=0
     fi
-    
-    CPPCHECK_VERSION="$(cppcheck --version)"
-    if [[ $CPPCHECK_VERSION = Cppcheck* ]] 
+
+    if [[ "$(cppcheck --version)" = Cppcheck* ]]
     then
         CPPCHECK_INTSALLED=1
     else
         CPPCHECK_INSTALLED=0
+        echo "cppcheck not installed, skipping..."
     fi
-    
-    VALGRIND_VERSION="$(valgrind --version)"
-    if [[ $VALGRIND_VERSION = valgrind* ]] 
+
+    if [[ "$(valgrind --version)" = valgrind* ]]
     then
         VALGRIND_INSTALLED=1
     else
         VALGRIND_INSTALLED=0
+        echo "valgrind not installed, skipping..."
     fi
 }
 
 function run_valgrind {
-    echo "Starting valgrind..." 
+    echo "Starting valgrind..."
     cd build
     if [[ ! -d valgrindReports ]]
     then
@@ -132,29 +133,30 @@ function run_rats {
 }
 
 function run_analysis {
-    check_installed_software
+	check_installed_software
+
     if [[ VALGRIND_INSTALLED -eq 1 ]]
     then
         run_valgrind
     fi
-    
+
     if [[ CPPCHECK_INTSALLED -eq 1 ]]
     then
         run_cppcheck
     fi
-    
+
     if [[ RATS_INSTALLED -eq 1 ]]
-    then
+	then
         run_rats
     fi
-} 
+}
 
 function clean {
     if [[ -d build ]]
     then
         cd build
         if [[ -f Makefile ]]
-        then 
+        then
             make clean
         fi
         cd .. && rm -r build
@@ -168,7 +170,7 @@ case "$cmd" in
     build)
         COLLECT_COVERAGE=0
         UNITTESTS_COMPILE=0
-        prepare_build &&
+        prepare_build
         build
     ;;
 
@@ -179,16 +181,16 @@ case "$cmd" in
     test)
         COLLECT_COVERAGE=1
         UNITTESTS_COMPILE=1
-        prepare_build &&
-        build &&
-        execute_tests &&
+        prepare_build
+        build
+        execute_tests
         run_analysis
     ;;
 
     clean)
         clean
     ;;
-    
+
     *)
         help
     ;;


### PR DESCRIPTION
Invoking of different tools are protected, so
they will not be mistakenely triggered if they are not installed.
