### PR TITLE
Fixed calculation of new_buffer_size

### DIFF
--- a/client/client-multi/client-c/src/kaa/utilities/kaa_buffer.c
+++ b/client/client-multi/client-c/src/kaa/utilities/kaa_buffer.c
@@ -77,7 +77,7 @@ kaa_error_t kaa_buffer_reallocate_space(kaa_buffer_t *buffer_p, size_t size)
     size_t locked_space    = buffer_p->current - buffer_p->begin;
     size_t free_space      = buffer_p->end     - buffer_p->current;
     size_t total_space     = buffer_p->end     - buffer_p->begin;
-    size_t new_buffer_size = size - free_space + locked_space;
+    size_t new_buffer_size = size + locked_space;
     char *ptr;
 
     if (total_space >= new_buffer_size)

--- a/client/client-multi/client-c/src/kaa/utilities/kaa_buffer.c
+++ b/client/client-multi/client-c/src/kaa/utilities/kaa_buffer.c
@@ -75,7 +75,6 @@ kaa_error_t kaa_buffer_reallocate_space(kaa_buffer_t *buffer_p, size_t size)
 {
     KAA_RETURN_IF_NIL(buffer_p, KAA_ERR_BADPARAM);
     size_t locked_space    = buffer_p->current - buffer_p->begin;
-    size_t free_space      = buffer_p->end     - buffer_p->current;
     size_t total_space     = buffer_p->end     - buffer_p->begin;
     size_t new_buffer_size = size + locked_space;
     char *ptr;

--- a/client/client-multi/client-c/test/utilities/test_kaa_reallocation.c
+++ b/client/client-multi/client-c/test/utilities/test_kaa_reallocation.c
@@ -48,6 +48,14 @@ void test_reallocation(void **state)
 
     error_code = kaa_buffer_lock_space(buffer_ptr, BUFFER_SIZE);
     ASSERT_EQUAL(error_code, KAA_ERR_NONE);
+    
+    // Test reallocation with free space already in the buffer
+    error_code = kaa_buffer_reallocate_space(buffer_ptr, BUFFER_SIZE);
+    ASSERT_EQUAL(error_code, KAA_ERR_NONE);
+    error_code = kaa_buffer_reallocate_space(buffer_ptr, BUFFER_SIZE*2);
+    ASSERT_EQUAL(error_code, KAA_ERR_NONE);
+    error_code = kaa_buffer_lock_space(buffer_ptr, BUFFER_SIZE*2);
+    ASSERT_EQUAL(error_code, KAA_ERR_NONE);
 
     kaa_buffer_destroy(buffer_ptr);
 }


### PR DESCRIPTION
While sending events over Kaa, we encountered problems with larger message sizes. I tracked the issue to the calculation of new_buffer_size that seems to be off.

The attached solution solves the problem and I thought you might be interested in including this.

Only tested briefly on POSIX where realloc takes the new total size as parameter - not sure if it works on all the other of your supported platforms.
