### PR TITLE
KAA-942: Deep schema export fails with CTL dependencies

### DIFF
--- a/server/common/dao/src/main/java/org/kaaproject/kaa/server/common/dao/service/CTLServiceImpl.java
+++ b/server/common/dao/src/main/java/org/kaaproject/kaa/server/common/dao/service/CTLServiceImpl.java
@@ -553,13 +553,8 @@ public class CTLServiceImpl implements CTLService {
                 ObjectNode dependency = (ObjectNode) node;
                 String fqn = dependency.get(FQN).getTextValue();
                 Integer version = dependency.get(VERSION).getIntValue();
-                CTLSchemaDto child = this.findCTLSchemaByFqnAndVerAndTenantIdAndApplicationId(
+                CTLSchemaDto child = this.findAnyCTLSchemaByFqnAndVerAndTenantIdAndApplicationId(
                         fqn, version, parent.getMetaInfo().getTenantId(), parent.getMetaInfo().getApplicationId());
-                if (child == null) { // Not found within the application scope
-                    String tenantId = parent.getMetaInfo().getTenantId();
-                    String applicationId = null; // Search within the tenant scope then
-                    child = this.findAnyCTLSchemaByFqnAndVerAndTenantIdAndApplicationId(fqn, version, tenantId, applicationId);
-                }
                 Validate.notNull(child, MessageFormat.format("The dependency [{0}] was not found!", fqn));
                 this.recursiveShallowExport(files, child);
             }

--- a/server/common/dao/src/main/java/org/kaaproject/kaa/server/common/dao/service/CTLServiceImpl.java
+++ b/server/common/dao/src/main/java/org/kaaproject/kaa/server/common/dao/service/CTLServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang.Validate;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ArrayNode;
@@ -554,6 +555,12 @@ public class CTLServiceImpl implements CTLService {
                 Integer version = dependency.get(VERSION).getIntValue();
                 CTLSchemaDto child = this.findCTLSchemaByFqnAndVerAndTenantIdAndApplicationId(
                         fqn, version, parent.getMetaInfo().getTenantId(), parent.getMetaInfo().getApplicationId());
+                if (child == null) { // Not found within the application scope
+                    String tenantId = parent.getMetaInfo().getTenantId();
+                    String applicationId = null; // Search within the tenant scope then
+                    child = this.findAnyCTLSchemaByFqnAndVerAndTenantIdAndApplicationId(fqn, version, tenantId, applicationId);
+                }
+                Validate.notNull(child, MessageFormat.format("The dependency [{0}] was not found!", fqn));
                 this.recursiveShallowExport(files, child);
             }
         }


### PR DESCRIPTION
The dependencies were searched for using the parent schema's application ID only, thus making it impossible to reference any common types within the tenant scope.
