### PR TITLE
KAA-857: Use CMAKE_BUILD_TYPE instead of KAA_DEBUG_ENABLED

### DIFF
--- a/client/client-multi/client-cpp/CMakeLists.txt
+++ b/client/client-multi/client-cpp/CMakeLists.txt
@@ -58,16 +58,9 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif ()
 
-if (KAA_DEBUG_ENABLED)
-    if (NOT MSVC)
-       set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb")
-    endif () 
-else()
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
-    if (CMAKE_COMPILER_IS_GNUCXX)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
-    endif()
-endif()
+if (NOT MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb")
+endif ()
 
 #Compiler specific flags
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -78,13 +71,6 @@ endif()
 if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x") 
 endif ()
-
-# Release version is built by default.
-if(KAA_DEBUG_ENABLED)
-    set(CMAKE_BUILD_TYPE DEBUG)
-else()
-    set(CMAKE_BUILD_TYPE RELEASE)
-endif()
 
 #
 # Sets maximum Kaa SDK log level.
@@ -98,7 +84,7 @@ endif()
 # DEBUG - 5
 # TRACE - 6
 if(NOT DEFINED KAA_MAX_LOG_LEVEL)
-    if(KAA_DEBUG_ENABLED)
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
         set(KAA_MAX_LOG_LEVEL 6)
     else()
         set(KAA_MAX_LOG_LEVEL 4)
@@ -313,7 +299,7 @@ if (SQLITE_LOG_STORAGE_ENABLED)
     target_link_libraries(kaacpp ${SQLITE3_LIBRARY})
 endif()
 
-if (WIN32 AND KAA_DEBUG_ENABLED)
+if (WIN32 AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     target_link_libraries(kaacpp dbghelp)
 endif()
 


### PR DESCRIPTION
cc @rasendubi @forGGe 
