### PR TITLE
KAA-1070: Add doxygen target to cmake

### DIFF
--- a/client/client-multi/client-c/CMakeLists.txt
+++ b/client/client-multi/client-c/CMakeLists.txt
@@ -189,3 +189,5 @@ install(TARGETS ${KAA_BUILD_SHARED} ${KAA_BUILD_STATIC} DESTINATION lib)
 if(KAA_UNITTESTS_COMPILE)
     include(${CMAKE_CURRENT_SOURCE_DIR}/listfiles/UnitTest.cmake)
 endif()
+
+add_subdirectory(Modules/doxygen)

--- a/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
+++ b/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
@@ -21,7 +21,8 @@ include (FindDoxygen)
 if(DOXYGEN_FOUND)
 
    add_custom_target(doxygen
-     ${DOXYGEN_EXECUTABLE}
+     COMMAND ${CMAKE_COMMAND} -E make_directory target/apidocs/doxygen
+     COMMAND ${DOXYGEN_EXECUTABLE}
      Doxyfile
      WORKING_DIRECTORY
      ${KAA_SDK_DIR}

--- a/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
+++ b/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
@@ -16,14 +16,13 @@
 
 # This cmake list is resposible for building doxygen documentation.
 
-include (FindDoxygen)
+find_package (Doxygen REQUIRED)
 
 if(DOXYGEN_FOUND)
 
    add_custom_target(doxygen
      COMMAND ${CMAKE_COMMAND} -E make_directory target/apidocs/doxygen
-     COMMAND ${DOXYGEN_EXECUTABLE}
-     Doxyfile
+     COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
      WORKING_DIRECTORY
      ${KAA_SDK_DIR}
      COMMENT "Generating doxygen docs"

--- a/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
+++ b/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
@@ -1,0 +1,32 @@
+#
+# Copyright 2014-2016 CyberVision, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This cmake list is resposible for building doxygen documentation.
+
+include (FindDoxygen)
+
+if(DOXYGEN_FOUND)
+
+   add_custom_target(doxygen
+     ${DOXYGEN_EXECUTABLE}
+     Doxyfile
+     WORKING_DIRECTORY
+     ${KAA_SDK_DIR}
+     COMMENT "Generating doxygen docs"
+     VERBATIM
+     )
+
+endif()

--- a/client/client-multi/client-c/scripts/build.sh
+++ b/client/client-multi/client-c/scripts/build.sh
@@ -18,9 +18,7 @@
 set -e
 set -v
 
-# Stupid doxygen can't create a directory
-mkdir -p target/apidocs
-doxygen
+make doxygen
 
 make
 


### PR DESCRIPTION
The initial purpose of the commit is
moving responsibility of the doxygen documentation
generation to cmake build system.
