### PR TITLE
KAA-1070: Improve build procedure

### DIFF
--- a/client/client-multi/client-c/CMakeLists.txt
+++ b/client/client-multi/client-c/CMakeLists.txt
@@ -17,7 +17,6 @@
 cmake_minimum_required(VERSION 2.8.8)
 
 project(Kaa-c C)
-enable_testing()
 
 option(WITH_EXTENSION_PROFILE "Enable profile extension" ON)
 option(WITH_EXTENSION_CONFIGURATION "Enable configuration extension" ON)

--- a/client/client-multi/client-c/Modules/cppcheck/CMakeLists.txt
+++ b/client/client-multi/client-c/Modules/cppcheck/CMakeLists.txt
@@ -16,11 +16,17 @@
 
 # This cmake list is responsible for running cppcheck against sources.
 
-add_custom_target(cppcheck
-    COMMAND cppcheck --quiet --enable=all --std=c99 --suppress=unusedFunction
-                     --force --error-exitcode=1 --template=gcc -I src/kaa
-                     --inline-suppr src/ test/
-    WORKING_DIRECTORY ${KAA_SDK_DIR}
-    COMMENT "Running cppcheck"
-    VERBATIM
-    )
+find_program(CPPCHECK_COMMAND cppcheck)
+
+if(CPPCHECK_COMMAND)
+   add_custom_target(cppcheck
+     COMMAND ${CPPCHECK_COMMAND} --quiet --enable=all --std=c99 --suppress=unusedFunction
+                                 --force --error-exitcode=1 --template=gcc -I src/kaa
+                                 --inline-suppr src/ test/
+     WORKING_DERICTORY ${KAA_SDK_DIR}
+     COMMENT "Running cppcheck"
+     VERBATIM
+     )
+else()
+  message (STATUS "Could NOT find cppcheck")
+endif()

--- a/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
+++ b/client/client-multi/client-c/Modules/doxygen/CMakeLists.txt
@@ -16,16 +16,13 @@
 
 # This cmake list is responsible for building doxygen documentation.
 
-find_package(Doxygen REQUIRED)
+find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
-
-   add_custom_target(doxygen
-     COMMAND ${CMAKE_COMMAND} -E make_directory target/apidocs/doxygen
-     COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
-     WORKING_DIRECTORY ${KAA_SDK_DIR}
-     COMMENT "Generating doxygen docs"
-     VERBATIM
-     )
-
-endif()
+add_custom_target(doxygen
+  COMMAND ${CMAKE_COMMAND} -E make_directory target/apidocs/doxygen
+  COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
+  WORKING_DIRECTORY
+  ${KAA_SDK_DIR}
+  COMMENT "Generating doxygen docs"
+  VERBATIM
+  )

--- a/client/client-multi/client-c/build.sh
+++ b/client/client-multi/client-c/build.sh
@@ -21,7 +21,7 @@ set -e
 RUN_DIR=`pwd`
 
 help() {
-    echo "Choose one of the following: {build|install|test|clean}"
+    echo "Choose one of the following: {build|install|test|analyze|clean}"
     exit 1
 }
 
@@ -35,14 +35,10 @@ then
     MAX_LOG_LEVEL=6
 fi
 
-BUILD_TYPE="Debug"
-UNITTESTS_COMPILE=0
-COLLECT_COVERAGE=0
-
 prepare_build() {
     mkdir -p build-posix
     cd build-posix
-    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DKAA_MAX_LOG_LEVEL=$MAX_LOG_LEVEL -DKAA_UNITTESTS_COMPILE=$UNITTESTS_COMPILE -DKAA_COLLECT_COVERAGE=$COLLECT_COVERAGE .. -DCMAKE_C_FLAGS="-Werror"
+    cmake -DCMAKE_BUILD_TYPE=Debug -DKAA_MAX_LOG_LEVEL=$MAX_LOG_LEVEL -DKAA_UNITTESTS_COMPILE=1 -DKAA_COLLECT_COVERAGE=1 .. -DCMAKE_C_FLAGS="-Werror"
     cd ..
 }
 
@@ -52,88 +48,18 @@ build() {
     cd ..
 }
 
-execute_tests() {
+run_analysis() {
+    cd build-posix
+    ctest -T memcheck
+    ctest -T coverage
+    make cppcheck
+    cd ..
+}
+
+run_tests() {
     cd build-posix
     ctest --output-on-failure .
     cd ..
-}
-
-check_installed_software() {
-    if hash rats 2>/dev/null
-    then
-        RATS_INSTALLED=1
-    else
-        echo "Rats is not installed, skipping..."
-        RATS_INSTALLED=0
-    fi
-
-    if hash cppcheck 2>/dev/null
-    then
-        CPPCHECK_INSTALLED=1
-    else
-        CPPCHECK_INSTALLED=0
-        echo "cppcheck not installed, skipping..."
-    fi
-
-
-    if hash valgrind 2>/dev/null
-    then
-        VALGRIND_INSTALLED=1
-    else
-        VALGRIND_INSTALLED=0
-        echo "valgrind not installed, skipping..."
-    fi
-}
-
-run_valgrind() {
-    echo "Starting valgrind..."
-    cd build-posix
-    if [ ! -d valgrindReports ]
-    then
-        mkdir valgrindReports
-    fi
-
-    # CMake supports running memory checker (like valgrind) only as a step
-    # of CDash.
-    # Calling valgrind externally in relation to CTest is viable workaround.
-    # Possibly, this will be moved someday into the Kaa build system in a form
-    # of a cmake script.
-    valgrind --leak-check=full --show-reachable=yes --trace-children=yes -v \
-    --log-file=valgrind.log --xml=yes --xml-file=valgrindReports/%p.memreport.xml \
-    ctest --output-on-failure
-
-    cd ..
-    echo "Valgrind analysis finished."
-}
-
-run_cppcheck() {
-    echo "Starting Cppcheck..."
-    cppcheck --enable=all --std=c99 --xml --suppress=unusedFunction src/ test/ 2>build-posix/cppcheck_.xml > build-posix/cppcheck.log
-    sed 's@file=\"@file=\"client\/client-multi\/client-c\/@g' build-posix/cppcheck_.xml > build-posix/cppcheck.xml
-    rm build-posix/cppcheck_.xml
-    echo "Cppcheck analysis finished."
-}
-
-run_rats() {
-    echo "Starting RATS..."
-    rats --xml `find src/ -name *.[ch]` > build-posix/rats-report.xml
-    echo "RATS analysis finished."
-}
-
-run_analysis() {
-    check_installed_software
-
-    if [ $VALGRIND_INSTALLED -eq 1 ]; then
-        run_valgrind
-    fi
-
-    if [ $CPPCHECK_INSTALLED -eq 1 ]; then
-        run_cppcheck
-    fi
-
-    if [ $RATS_INSTALLED -eq 1 ]; then
-        run_rats
-    fi
 }
 
 clean() {
@@ -153,8 +79,6 @@ do
 
 case "$cmd" in
     build)
-        COLLECT_COVERAGE=0
-        UNITTESTS_COMPILE=0
         prepare_build
         build
     ;;
@@ -164,11 +88,12 @@ case "$cmd" in
     ;;
 
     test)
-        COLLECT_COVERAGE=1
-        UNITTESTS_COMPILE=1
         prepare_build
         build
-        execute_tests
+        run_tests
+    ;;
+
+    analyze)
         run_analysis
     ;;
 

--- a/client/client-multi/client-c/listfiles/UnitTest.cmake
+++ b/client/client-multi/client-c/listfiles/UnitTest.cmake
@@ -14,11 +14,13 @@
 # limitations under the License.
 #
 
-enable_testing()
-
 if(KAA_UNITTESTS_COMPILE)
     find_package(cmocka REQUIRED)
     find_package(OpenSSL REQUIRED)
+    find_program(MEMORYCHECK_COMMAND  valgrind)
+    set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-reachable=yes --trace-children=yes -v")
+
+    include(CTest)
 endif()
 
 ################################################################################

--- a/client/client-multi/client-c/listfiles/UnitTest.cmake
+++ b/client/client-multi/client-c/listfiles/UnitTest.cmake
@@ -17,7 +17,7 @@
 if(KAA_UNITTESTS_COMPILE)
     find_package(cmocka REQUIRED)
     find_package(OpenSSL REQUIRED)
-    find_program(MEMORYCHECK_COMMAND  valgrind)
+    find_program(MEMORYCHECK_COMMAND valgrind)
     set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-reachable=yes --trace-children=yes -v")
 
     include(CTest)

--- a/client/client-multi/client-c/scripts/build.sh
+++ b/client/client-multi/client-c/scripts/build.sh
@@ -21,6 +21,7 @@ set -v
 make
 
 cd build-posix
+ctest -T test
 ctest -T memcheck
 ctest -T coverage
 cd ..

--- a/client/client-multi/client-c/scripts/build.sh
+++ b/client/client-multi/client-c/scripts/build.sh
@@ -20,7 +20,10 @@ set -v
 
 make
 
-./build.sh test
+cd build-posix
+ctest -T memcheck
+ctest -T coverage
+cd ..
 
 make -C build-posix doxygen
 

--- a/nix/kaa-client-c/default.nix
+++ b/nix/kaa-client-c/default.nix
@@ -85,7 +85,7 @@ let
         __propagate:;
       ''
       + target posixSupport "posix"
-              "${lib.optionalString testSupport ''-DKAA_UNITTESTS_COMPILE=on''}"
+              "${lib.optionalString testSupport ''-DCMAKE_BUILD_TYPE=Debug -DKAA_UNITTESTS_COMPILE=on -DKAA_COLLECT_COVERAGE=1 ''}"
       + target posixSupport "nologs"
               "${lib.optionalString testSupport ''-DKAA_UNITTESTS_COMPILE=on''} -DKAA_MAX_LOG_LEVEL=0"
       + target clangSupport "clang"

--- a/nix/kaa-client-c/default.nix
+++ b/nix/kaa-client-c/default.nix
@@ -85,7 +85,7 @@ let
         __propagate:;
       ''
       + target posixSupport "posix"
-              "${lib.optionalString testSupport ''-DCMAKE_BUILD_TYPE=Debug -DKAA_UNITTESTS_COMPILE=on -DKAA_COLLECT_COVERAGE=1 ''}"
+              "${lib.optionalString testSupport ''-DCMAKE_BUILD_TYPE=Debug -DKAA_UNITTESTS_COMPILE=on -DKAA_COLLECT_COVERAGE=1''}"
       + target posixSupport "nologs"
               "${lib.optionalString testSupport ''-DKAA_UNITTESTS_COMPILE=on''} -DKAA_MAX_LOG_LEVEL=0"
       + target clangSupport "clang"


### PR DESCRIPTION
- moves memory check to cmake
- moves coverage to cmake
- makes cppcheck and doxygen build optional
- improves build.sh script
