### PR TITLE
KAA-1096: Remove "Download configuration" button from Profile filter in Admin UI

### DIFF
--- a/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/view/struct/BaseStructView.java
+++ b/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/view/struct/BaseStructView.java
@@ -73,13 +73,12 @@ public abstract class BaseStructView<T extends AbstractStructureDto, V> extends 
     private Button saveButton;
     private Button activateButton;
     private Button deactivateButton;
-    private Button downloadConfigurationButton;
 
     private boolean active;
 
     private Label bodyLabel;
 
-    private HorizontalPanel buttonsPanel;
+    protected HorizontalPanel buttonsPanel;
 
     protected List<HandlerRegistration> registrations = new ArrayList<HandlerRegistration>();
 
@@ -88,7 +87,7 @@ public abstract class BaseStructView<T extends AbstractStructureDto, V> extends 
         init();
     }
 
-    private void init() {
+    protected void init() {
 
         getColumnFormatter().setWidth(0, "400px");
         getColumnFormatter().setWidth(1, "400px");
@@ -208,11 +207,9 @@ public abstract class BaseStructView<T extends AbstractStructureDto, V> extends 
         saveButton = new Button(Utils.constants.save());
         activateButton = new Button(Utils.constants.activate());
         deactivateButton = new Button(Utils.constants.deactivate());
-        downloadConfigurationButton = new Button(Utils.constants.downloadConfiguration());
         buttonsPanel.add(saveButton);
         buttonsPanel.add(activateButton);
         buttonsPanel.add(deactivateButton);
-        buttonsPanel.add(downloadConfigurationButton);
 
         description.setFocus(true);
 
@@ -220,16 +217,6 @@ public abstract class BaseStructView<T extends AbstractStructureDto, V> extends 
             @Override
             public void onClick(ClickEvent event) {
                 updateSaveButton(false, false);
-            }
-        });
-
-        downloadConfigurationButton.addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent clickEvent) {
-                String url = Window.Location.getHref();
-                Window.open("/kaaAdmin/servlet/kaaConfigurationDownloadServlet?schemaId=" + Utils.getSchemaIdFromUrl(url) +
-                                "&endGroupId=" + Utils.getEndpointGroupIdFromUrl(url),
-                        "_blank", "status=0,toolbar=0,menubar=0,location=0");
             }
         });
     }

--- a/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/view/struct/ConfigFormStructView.java
+++ b/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/view/struct/ConfigFormStructView.java
@@ -16,7 +16,12 @@
 
 package org.kaaproject.kaa.server.admin.client.mvp.view.struct;
 
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Button;
 import org.kaaproject.avro.ui.shared.RecordField;
+import org.kaaproject.kaa.common.dto.UpdateStatus;
 import org.kaaproject.kaa.server.admin.client.mvp.view.widget.RecordPanel;
 import org.kaaproject.kaa.server.admin.client.util.HasErrorMessage;
 import org.kaaproject.kaa.server.admin.client.util.Utils;
@@ -28,6 +33,8 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.HasValue;
 
 public class ConfigFormStructView extends BaseStructView<ConfigurationRecordFormDto, RecordField> {
+
+    private Button downloadConfigurationButton;
 
     public ConfigFormStructView(HasErrorMessage hasErrorMessage) {
         super(hasErrorMessage);
@@ -64,6 +71,38 @@ public class ConfigFormStructView extends BaseStructView<ConfigurationRecordForm
                 fireChanged();
             }
         });
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        downloadConfigurationButton = new Button(Utils.constants.downloadConfiguration());
+
+        buttonsPanel.add(downloadConfigurationButton);
+
+        downloadConfigurationButton.addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent clickEvent) {
+                String url = Window.Location.getHref();
+                Window.open("/kaaAdmin/servlet/kaaConfigurationDownloadServlet?schemaId=" + Utils.getSchemaIdFromUrl(url) +
+                                "&endGroupId=" + Utils.getEndpointGroupIdFromUrl(url),
+                        "_blank", "status=0,toolbar=0,menubar=0,location=0");
+            }
+        });
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        downloadConfigurationButton.setVisible(false);
+    }
+
+    @Override
+    public void setData(ConfigurationRecordFormDto struct) {
+        super.setData(struct);
+        if (struct.getStatus()==UpdateStatus.ACTIVE) {
+            downloadConfigurationButton.setVisible(true);
+        }
     }
 
     @Override

--- a/server/node/src/main/resources/org/kaaproject/kaa/server/admin/client/i18n/KaaAdminConstants.properties
+++ b/server/node/src/main/resources/org/kaaproject/kaa/server/admin/client/i18n/KaaAdminConstants.properties
@@ -171,7 +171,7 @@ deactivate = Deactivate
 
 deactivatedBy = Deactivated by
 
-downloadConfiguration = Download configuration
+downloadConfiguration = Download
 
 deep = Deep
 


### PR DESCRIPTION
Was removed "Download configuration" button in the Profile filter section.
Was renamed "Download configuration" button to "Download" in the Configuration section.
