### PR TITLE
KAA-1051: PostgreSQL database driver not found exception while Kaa 0.9.0 deb installation

### DIFF
--- a/server/common/dao/pom.xml
+++ b/server/common/dao/pom.xml
@@ -299,12 +299,6 @@
 		</profile>
 		<profile>
 			<id>mariadb-dao</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.mariadb.jdbc</groupId>
-					<artifactId>mariadb-java-client</artifactId>
-				</dependency>
-			</dependencies>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
@@ -334,12 +328,6 @@
 		</profile>
 		<profile>
 			<id>postgresql-dao</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.postgresql</groupId>
-					<artifactId>postgresql</artifactId>
-				</dependency>
-			</dependencies>
 			<build>
 				<plugins>
 					<plugin>

--- a/server/node/pom.xml
+++ b/server/node/pom.xml
@@ -272,12 +272,10 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
@@ -1124,12 +1122,6 @@
     <profiles>
         <profile>
             <id>mariadb-dao</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.mariadb.jdbc</groupId>
-                    <artifactId>mariadb-java-client</artifactId>
-                </dependency>
-            </dependencies>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -1159,12 +1151,6 @@
         </profile>
         <profile>
             <id>postgresql-dao</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.postgresql</groupId>
-                    <artifactId>postgresql</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Added database drivers of PostgreSQL and MariaDB to general dependencies in kaa-node module
