### PR TITLE
KAA-1200 Drop Snappy Ubuntu page

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Ubuntu-Snappy/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Ubuntu-Snappy/index.md
@@ -1,8 +1,0 @@
----
-layout: page
-title: Snappy Ubuntu Core
-permalink: /:path/
-sort_idx: 80
----
-
-SDK integration instructions for select platforms

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/index.md
@@ -40,7 +40,6 @@ Below is the list of the targets for which C SDK already has an implementation o
     - [Linux]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/)
     - [UDOO]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-UDOO/)
     - [Windows (cygwin)]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Windows)
-    - [Snappy Ubuntu Core]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Ubuntu-Snappy/)
     - [Raspberry PI]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-RPi/)
     - [Beaglebone]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Beaglebone/)
     - [QNX Neutrino]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-QNX-Neutrino/)


### PR DESCRIPTION
The page should be removed as it has numerous issues:

```
- Snappy Ubuntu Core is not a target. There is no special support for it in the C SDK.
- The biggest part of the guide is dedicated to generating the SDK, which should be covered elsewhere. (UI guide)
- It's not specific to the C SDK. The most valuable part of the guide describes packaging
  the final application in the Snappy Ubuntu Core package. That has nothing to do with the C SDK and
  may be generalized to any SDK.
- The guide does some nasty things like replacing the generated SDK with latest one from git,
  which may cause severe compatibility issues.
- Cross-compiling issues. The C application should be delivered to the final device and should be cross-compiled for it.
  Contrary, the guide describes the build for the host platform and expects to be run in the VM,
  which is not true most C endpoints (there is no point developing in C if you can afford running a VM).
```
