### PR TITLE
KAA-1183 [C SDK] Allow overriding xtensa-lx106-elf-gcc path

### DIFF
--- a/client/client-multi/client-c/toolchains/esp8266.cmake
+++ b/client/client-multi/client-c/toolchains/esp8266.cmake
@@ -20,46 +20,46 @@
 
 include(CMakeForceCompiler)
 
-set(ARM_GCC_COMPILER "xtensa-lx106-elf-gcc${CMAKE_EXECUTABLE_SUFFIX}")
+set(XTENSA_GCC_COMPILER "xtensa-lx106-elf-gcc${CMAKE_EXECUTABLE_SUFFIX}")
 
-if(DEFINED ENV{ESP8266_TOOLCHAIN_PATH})
-  set(TOOLCHAIN_PATH "$ENV{ESP8266_TOOLCHAIN_PATH}")
-  message(STATUS "Toolchain path is provided: ${TOOLCHAIN_PATH}")
-else ()
+if (NOT DEFINED ESP8266_TOOLCHAIN_PATH)
   # Check if GCC is reachable.
-  find_path(TOOLCHAIN_PATH bin/${ARM_GCC_COMPILER})
+  find_path(ESP8266_TOOLCHAIN_PATH bin/${XTENSA_GCC_COMPILER})
 
-  if (NOT TOOLCHAIN_PATH)
+  if (NOT ESP8266_TOOLCHAIN_PATH)
     # Set default path.
-    set(TOOLCHAIN_PATH /opt/Espressif/crosstool-NG/builds/xtensa-lx106-elf)
-    message(STATUS "GCC not found, default path will be used")
+    set(ESP8266_TOOLCHAIN_PATH /opt/Espressif/crosstool-NG/builds/xtensa-lx106-elf)
+    message(STATUS "GCC not found, default path will be used: ${ESP8266_TOOLCHAIN_PATH}")
   endif ()
+else ()
+  message(STATUS "Toolchain path: ${ESP8266_TOOLCHAIN_PATH}")
 endif ()
 
-CMAKE_FORCE_C_COMPILER(${TOOLCHAIN_PATH}/bin/xtensa-lx106-elf-gcc GNU)
+CMAKE_FORCE_C_COMPILER(${ESP8266_TOOLCHAIN_PATH}/bin/${XTENSA_GCC_COMPILER} GNU)
 
-set(CMAKE_OBJCOPY ${TOOLCHAIN_PATH}/bin/xtensa-lx106-elf-objcopy CACHE PATH "")
+set(CMAKE_OBJCOPY ${ESP8266_TOOLCHAIN_PATH}/bin/xtensa-lx106-elf-objcopy CACHE PATH "")
 
 #########################
 ### ESP8266 SDK setup ###
 #########################
 
-if(DEFINED ENV{ESP8266_SDK_BASE})
-    set(ESP8266_SDK_BASE $ENV{ESP8266_SDK_BASE})
-else()
-    set(ESP8266_SDK_BASE /opt/Espressif/esp-rtos-sdk)
-endif()
+if (NOT DEFINED ESP8266_SDK_PATH)
+    set(ESP8266_SDK_PATH /opt/Espressif/esp-rtos-sdk)
+    message(STATUS "Default SDK location will be used: ${ESP8266_SDK_PATH}")
+else ()
+  message(STATUS "ESP8266 SDK path: ${ESP8266_SDK_PATH}")
+endif ()
 
-set(CMAKE_LIBRARY_PATH ${ESP8266_SDK_BASE}/lib/)
+set(CMAKE_LIBRARY_PATH ${ESP8266_SDK_PATH}/lib/)
 
 set(ESP8266_INCDIRS
-    ${ESP8266_SDK_BASE}/extra_include
-    ${ESP8266_SDK_BASE}/include
-    ${ESP8266_SDK_BASE}/include/lwip
-    ${ESP8266_SDK_BASE}/include/lwip/ipv4
-    ${ESP8266_SDK_BASE}/include/lwip/ipv6
-    ${ESP8266_SDK_BASE}/include/espressif/
-    ${TOOLCHAIN_PATH}/lib/gcc/xtensa-lx106-elf/4.8.2/include/
+    ${ESP8266_SDK_PATH}/extra_include
+    ${ESP8266_SDK_PATH}/include
+    ${ESP8266_SDK_PATH}/include/lwip
+    ${ESP8266_SDK_PATH}/include/lwip/ipv4
+    ${ESP8266_SDK_PATH}/include/lwip/ipv6
+    ${ESP8266_SDK_PATH}/include/espressif/
+    ${ESP8266_TOOLCHAIN_PATH}/lib/gcc/xtensa-lx106-elf/4.8.2/include/
     )
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -fno-builtin -Wno-implicit-function-declaration -Os -Wpointer-arith -Wl,-EL,--gc-sections -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -ffunction-sections" CACHE FORCE "")

--- a/client/client-multi/client-c/toolchains/esp8266.cmake
+++ b/client/client-multi/client-c/toolchains/esp8266.cmake
@@ -22,20 +22,20 @@ include(CMakeForceCompiler)
 
 set(XTENSA_GCC_COMPILER "xtensa-lx106-elf-gcc${CMAKE_EXECUTABLE_SUFFIX}")
 
-if (NOT DEFINED ESP8266_TOOLCHAIN_PATH)
-  # Check if GCC is reachable.
-  find_path(ESP8266_TOOLCHAIN_PATH bin/${XTENSA_GCC_COMPILER})
+if(NOT DEFINED ESP8266_TOOLCHAIN_PATH)
+    # Check if GCC is reachable.
+    find_path(ESP8266_TOOLCHAIN_PATH bin/${XTENSA_GCC_COMPILER})
 
-  if (NOT ESP8266_TOOLCHAIN_PATH)
-    # Set default path.
-    set(ESP8266_TOOLCHAIN_PATH /opt/Espressif/crosstool-NG/builds/xtensa-lx106-elf)
-    message(STATUS "GCC not found, default path will be used: ${ESP8266_TOOLCHAIN_PATH}")
-  endif ()
-else ()
-  message(STATUS "Toolchain path: ${ESP8266_TOOLCHAIN_PATH}")
-endif ()
+    if(NOT ESP8266_TOOLCHAIN_PATH)
+        # Set default path.
+        set(ESP8266_TOOLCHAIN_PATH /opt/Espressif/crosstool-NG/builds/xtensa-lx106-elf)
+        message(STATUS "GCC not found, default path will be used: ${ESP8266_TOOLCHAIN_PATH}")
+    endif()
+else()
+    message(STATUS "Toolchain path: ${ESP8266_TOOLCHAIN_PATH}")
+endif()
 
-CMAKE_FORCE_C_COMPILER(${ESP8266_TOOLCHAIN_PATH}/bin/${XTENSA_GCC_COMPILER} GNU)
+cmake_force_c_compiler(${ESP8266_TOOLCHAIN_PATH}/bin/${XTENSA_GCC_COMPILER} GNU)
 
 set(CMAKE_OBJCOPY ${ESP8266_TOOLCHAIN_PATH}/bin/xtensa-lx106-elf-objcopy CACHE PATH "")
 
@@ -43,24 +43,24 @@ set(CMAKE_OBJCOPY ${ESP8266_TOOLCHAIN_PATH}/bin/xtensa-lx106-elf-objcopy CACHE P
 ### ESP8266 SDK setup ###
 #########################
 
-if (NOT DEFINED ESP8266_SDK_PATH)
+if(NOT DEFINED ESP8266_SDK_PATH)
     set(ESP8266_SDK_PATH /opt/Espressif/esp-rtos-sdk)
     message(STATUS "Default SDK location will be used: ${ESP8266_SDK_PATH}")
-else ()
-  message(STATUS "ESP8266 SDK path: ${ESP8266_SDK_PATH}")
-endif ()
+else()
+    message(STATUS "ESP8266 SDK path: ${ESP8266_SDK_PATH}")
+endif()
 
 set(CMAKE_LIBRARY_PATH ${ESP8266_SDK_PATH}/lib/)
 
 set(ESP8266_INCDIRS
-    ${ESP8266_SDK_PATH}/extra_include
-    ${ESP8266_SDK_PATH}/include
-    ${ESP8266_SDK_PATH}/include/lwip
-    ${ESP8266_SDK_PATH}/include/lwip/ipv4
-    ${ESP8266_SDK_PATH}/include/lwip/ipv6
-    ${ESP8266_SDK_PATH}/include/espressif/
-    ${ESP8266_TOOLCHAIN_PATH}/lib/gcc/xtensa-lx106-elf/4.8.2/include/
-    )
+        ${ESP8266_SDK_PATH}/extra_include
+        ${ESP8266_SDK_PATH}/include
+        ${ESP8266_SDK_PATH}/include/lwip
+        ${ESP8266_SDK_PATH}/include/lwip/ipv4
+        ${ESP8266_SDK_PATH}/include/lwip/ipv6
+        ${ESP8266_SDK_PATH}/include/espressif/
+        ${ESP8266_TOOLCHAIN_PATH}/lib/gcc/xtensa-lx106-elf/4.8.2/include/
+        )
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -fno-builtin -Wno-implicit-function-declaration -Os -Wpointer-arith -Wl,-EL,--gc-sections -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -ffunction-sections" CACHE FORCE "")
 set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> -o <TARGET> -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> -Wl,--end-group" CACHE FORCE "")

--- a/nix/kaa-client-c/default.nix
+++ b/nix/kaa-client-c/default.nix
@@ -129,11 +129,10 @@ in stdenv.mkDerivation {
     raspberrypi-openssl
   ];
 
-  shellHook =
-    lib.optionalString esp8266Support ''
-      export CTEST_OUTPUT_ON_FAILURE=1
+  shellHook = ''
+    export CTEST_OUTPUT_ON_FAILURE=1
 
-      cp ${kaa-generic-makefile}/Makefile .
-      chmod 644 Makefile
-    '';
+    cp ${kaa-generic-makefile}/Makefile .
+    chmod 644 Makefile
+  '';
 }

--- a/nix/kaa-client-c/default.nix
+++ b/nix/kaa-client-c/default.nix
@@ -93,7 +93,7 @@ let
       + target cc3200Support "cc3200"
               "-DKAA_PLATFORM=cc32xx -DCMAKE_TOOLCHAIN_FILE=toolchains/cc32xx.cmake -DCC32XX_SDK='${cc3200-sdk}/lib/cc3200-sdk/cc3200-sdk' -DCC32XX_TOOLCHAIN_PATH='${gcc-arm-embedded}'"
       + target esp8266Support "esp8266"
-              "-DKAA_PLATFORM=esp8266 -DCMAKE_TOOLCHAIN_FILE=toolchains/esp8266.cmake"
+              "-DKAA_PLATFORM=esp8266 -DCMAKE_TOOLCHAIN_FILE=toolchains/esp8266.cmake -DESP8266_TOOLCHAIN_PATH='${gcc-xtensa-lx106}' -DESP8266_SDK_PATH='${esp8266-rtos-sdk}/lib/esp8266-rtos-sdk'"
       + target raspberrypiSupport "rpi"
               "-DCMAKE_PREFIX_PATH=${raspberrypi-openssl} -DCMAKE_TOOLCHAIN_FILE=toolchains/rpi.cmake";
     };
@@ -131,10 +131,6 @@ in stdenv.mkDerivation {
 
   shellHook =
     lib.optionalString esp8266Support ''
-      export ESP8266_TOOLCHAIN_PATH="${gcc-xtensa-lx106}"
-      export ESP8266_SDK_BASE=${esp8266-rtos-sdk}/lib/esp8266-rtos-sdk
-    '' +
-    ''
       export CTEST_OUTPUT_ON_FAILURE=1
 
       cp ${kaa-generic-makefile}/Makefile .


### PR DESCRIPTION
Added possibility to override toolchain and SDK pathes via Cmake variable
