### PR TITLE
Fix FindSqlite3.cmake

### DIFF
--- a/client/client-multi/client-cpp/Modules/FindSqlite3.cmake
+++ b/client/client-multi/client-cpp/Modules/FindSqlite3.cmake
@@ -11,14 +11,6 @@
 #    SQLITE3_INCLUDE_DIR
 #    SQLITE3_LIBRARY
 
-
-# FIND_PATH and FIND_LIBRARY normally search standard locations
-# before the specified paths. To search non-standard paths first,
-# FIND_* is invoked first with specified paths and NO_DEFAULT_PATH
-# and then again with no specified paths to search the default
-# locations. When an earlier FIND_* succeeds, subsequent FIND_*s
-# searching for the same item do nothing. 
-
 # try to use framework on mac
 # want clean framework path, not unix compatibility path
 IF (APPLE)
@@ -37,31 +29,8 @@ IF (APPLE)
   ENDIF ()
 ENDIF (APPLE)
 
-IF ($ENV{SQLITE_ROOT})
-    SET(SQLITE_HOME $ENV{LIB_DIR})
-    MESSAGE("SQLITE_HOME=${SQLITE_HOME}")
-ELSE ()
-    SET(SQLITE_HOME $ENV{SQLITE_ROOT})
-    MESSAGE("SQLITE_HOME=${SQLITE_HOME}")
-ENDIF ()
-
-FIND_PATH(SQLITE3_INCLUDE_DIR sqlite3.h
-  "${SQLITE_HOME}/include"
-  "${SQLITE_HOME}/include/sqlite"
-  #mingw
-  c:/msys/local/include
-  NO_DEFAULT_PATH
-  )
 FIND_PATH(SQLITE3_INCLUDE_DIR sqlite3.h)
 
-FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite3 sqlite3_i PATHS
-  $ENV{LIB} 
-  /usr/lib 
-  "${SQLITE_HOME}/lib"
-  #mingw
-  c:/msys/local/lib
-  NO_DEFAULT_PATH
-  )
 FIND_LIBRARY(SQLITE3_LIBRARY NAMES sqlite3)
 
 IF (SQLITE3_INCLUDE_DIR AND SQLITE3_LIBRARY)

--- a/nix/kaa-client-cpp/default.nix
+++ b/nix/kaa-client-cpp/default.nix
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 
-{ stdenv, cmake, pkgconfig, boost, avro-cpp, botanUnstable, sqlite, python
+{ stdenv, cmake, pkgconfig, boost155, avro-cpp, botanUnstable, sqlite, python
 , which
 }:
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   buildInputs = [
     cmake
     pkgconfig
-    boost
+    boost155
     avro-cpp
     botanUnstable
     sqlite


### PR DESCRIPTION
Remove a section from FindSqlite3.cmake to search in a custom location.
There are a couple of reasons for that. The first one is that cmake already
provides means to specify additional search paths. The second is an
issue of priorities -- they were wrong, so cmake ended up selecting host
sqlite3 when I tried to cross-compile.
