### PR TITLE
KAA-1288: ESP8266 C SDK CMakeLists: uses wrong path

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/attach/esp8266-sample/CMakeLists.txt
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/attach/esp8266-sample/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(kaa_demo C)
 
 # Add Kaa SDK directory
-add_subdirectory(libs/kaa)
+add_subdirectory(kaa)
 
 # Add source files
 add_library(kaa_demo_s STATIC user/user_main.c driver/uart.c src/kaa_demo.c)


### PR DESCRIPTION
Fixed KAA-1288
