### PR TITLE
KAA-1161 Big endian support for test_kaa_tcp_channel_bootstrap

### DIFF
--- a/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_tcp_channel.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_tcp_channel.c
@@ -1469,10 +1469,8 @@ static uint32_t get_uint32_t(const uint8_t *buffer)
         return 0;
     }
 
-    uint32_t value = ((uint32_t)buffer[3] << 24)
-            + ((uint32_t)buffer[2] << 16)
-            + ((uint32_t)buffer[1] << 8)
-            + ((uint32_t)buffer[0]);
+    uint32_t value = 0;
+    memcpy(&value, buffer, sizeof(value));
     return KAA_NTOHL(value);
 }
 

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -86,9 +86,11 @@ static uint8_t DISCONNECT_MESSAGE[] = {0xE0, 0x02, 0x00, 0x00};
 static uint8_t CONNECT_HEAD[] = {0x35, 0x46};
 static uint8_t CONNECT_PACK[] = {0x34, 0x45};
 
-static uint8_t DESTINATION_SOCKADDR[]   = {
-    0x02, 0x00, 0x26, 0xa0, 0xc0, 0xa8, 0x4d, 0x02,
+static kaa_sockaddr_t DESTINATION_SOCKADDR = {
+	.sa_family = 0x02,
+	.sa_data = { 0x26, (uint8_t)0xa0, (uint8_t)0xc0, (uint8_t)0xa8, 0x4d, 0x02,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+	}
 };
 
 static uint8_t CONNECTION_DATA[]   = {
@@ -730,8 +732,7 @@ ext_tcp_socket_state_t ext_tcp_utils_tcp_socket_check(kaa_fd_t fd, const kaa_soc
 {
 
     if (fd == ACCESS_POINT_SOCKET_FD) {
-        unsigned char *dst = (unsigned char*)destination;
-        if(!memcmp(dst,DESTINATION_SOCKADDR,destination_size)) {
+        if(!memcmp(destination, &DESTINATION_SOCKADDR,destination_size)) {
             if (access_point_test_info.socket_connecting_error_scenario) {
                 return KAA_TCP_SOCK_ERROR;
             } else {
@@ -796,9 +797,7 @@ kaa_error_t ext_tcp_utils_open_tcp_socket(kaa_fd_t *fd, const kaa_sockaddr_t *de
 {
     KAA_RETURN_IF_NIL3(fd, destination, destination_size, KAA_ERR_BADPARAM);
 
-    unsigned char *dst = (unsigned char*)destination;
-
-    if(!memcmp(dst,DESTINATION_SOCKADDR,destination_size)) {
+    if(!memcmp(destination, &DESTINATION_SOCKADDR,destination_size)) {
         access_point_test_info.new_socket_created = true;
         *fd = ACCESS_POINT_SOCKET_FD;
         return KAA_ERR_NONE;

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -87,10 +87,10 @@ static uint8_t CONNECT_HEAD[] = {0x35, 0x46};
 static uint8_t CONNECT_PACK[] = {0x34, 0x45};
 
 static kaa_sockaddr_t DESTINATION_SOCKADDR = {
-	.sa_family = 0x02,
-	.sa_data = { 0x26, (uint8_t)0xa0, (uint8_t)0xc0, (uint8_t)0xa8, 0x4d, 0x02,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-	}
+    .sa_family = 0x02,
+    .sa_data = { 0x26, (uint8_t)0xa0, (uint8_t)0xc0, (uint8_t)0xa8, 0x4d, 0x02,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    }
 };
 
 static uint8_t CONNECTION_DATA[]   = {
@@ -732,7 +732,7 @@ ext_tcp_socket_state_t ext_tcp_utils_tcp_socket_check(kaa_fd_t fd, const kaa_soc
 {
 
     if (fd == ACCESS_POINT_SOCKET_FD) {
-        if(!memcmp(destination, &DESTINATION_SOCKADDR,destination_size)) {
+        if(memcmp(destination, &DESTINATION_SOCKADDR,destination_size) == 0) {
             if (access_point_test_info.socket_connecting_error_scenario) {
                 return KAA_TCP_SOCK_ERROR;
             } else {
@@ -797,7 +797,7 @@ kaa_error_t ext_tcp_utils_open_tcp_socket(kaa_fd_t *fd, const kaa_sockaddr_t *de
 {
     KAA_RETURN_IF_NIL3(fd, destination, destination_size, KAA_ERR_BADPARAM);
 
-    if(!memcmp(destination, &DESTINATION_SOCKADDR,destination_size)) {
+    if(memcmp(destination, &DESTINATION_SOCKADDR,destination_size) == 0) {
         access_point_test_info.new_socket_created = true;
         *fd = ACCESS_POINT_SOCKET_FD;
         return KAA_ERR_NONE;


### PR DESCRIPTION
DESTINATION_SOCKADDR is a 2 fields structure.
First field is a sa_family with the type of uint16_t in native endian and a second field is sa_data in network endian. In array, sa_family was hard coded to little-endian.

> -    uint32_t value = ((uint32_t)buffer[3] << 24)
> -            + ((uint32_t)buffer[2] << 16)
> -            + ((uint32_t)buffer[1] << 8)
> -            + ((uint32_t)buffer[0]);

Just ugly and doesn't work on big-endian.
/cc @forGGe @rasendubi 
