### PR TITLE
KAA-1161 Support for 32 bit architectures for test_kaa_log

### DIFF
--- a/client/client-multi/client-c/src/extensions/logging/test/test_kaa_log.c
+++ b/client/client-multi/client-c/src/extensions/logging/test/test_kaa_log.c
@@ -619,7 +619,7 @@ void test_max_parallel_uploads_with_log_sync(void **state)
 
     mock_strategy_context_t strategy;
     memset(&strategy, 0, sizeof(mock_strategy_context_t));
-    strategy.timeout = UINT32_MAX;
+    strategy.timeout = INT16_MAX;
     strategy.decision = UPLOAD;
 
     mock_storage_context_t *storage = create_mock_storage();
@@ -701,7 +701,7 @@ void test_max_parallel_uploads_with_sync_all(void **state)
 
     mock_strategy_context_t strategy;
     memset(&strategy, 0, sizeof(mock_strategy_context_t));
-    strategy.timeout = UINT32_MAX;
+    strategy.timeout = INT16_MAX;
     strategy.decision = UPLOAD;
 
     mock_storage_context_t *storage = create_mock_storage();


### PR DESCRIPTION
The issue : kaa_time_t is typedefed to different types

```
./client-c/src/kaa/platform-impl/posix/platform/time.h:typedef time_t kaa_time_t;
./client-c/src/kaa/platform-impl/cc32xx/platform/time.h:typedef long kaa_time_t;
./client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_time.h:typedef uint32_t kaa_time_t;
./client-c/src/kaa/platform-impl/esp8266/platform/time.h:typedef unsigned int kaa_time_t;
```

Log delivery deadline is calculated as

```
KAA_TIME() + strategy.timeout
```

And  in test 

```
strategy.timeout = UINT32_MAX;
```

It worked fine for x64 but on x32 due to check 

```
 if (KAA_TIME() >= info->deadline) {
```

it always failed. Also I don't see code for handling time overflow anywhere. 

/cc @forGGe  @rasendubi 
