### PR TITLE
KAA-1305: ESP8266 C SDK requires g++5 package

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/index.md
@@ -71,7 +71,7 @@ The detailed installation instructions can be found below.
 
 1. Prerequisites
 
-        sudo apt-get install autoconf libtool libtool-bin bison build-essential gawk git gperf flex texinfo libtool libncurses5-dev libc6-dev-amd64 python-serial libexpat-dev python-setuptools
+        sudo apt-get install autoconf libtool libtool-bin bison g++5 build-essential gawk git gperf flex texinfo libtool libncurses5-dev libc6-dev-amd64 python-serial libexpat-dev python-setuptools
 
 2. Set the `ESPRESSIF_HOME` variable.
 This variable will be used throughout the installation process, and denotes a directory where ESP8266 SDK and toolchain will be placed.


### PR DESCRIPTION
Added g++5 installation to "Installing dependencies" label
