### PR TITLE
KAA-1309 Minor inaccuracy on C++/SDK-Linux guide 

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Linux/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Linux/index.md
@@ -32,7 +32,7 @@ Before building the C++ endpoint SDK, install the following components on your m
 
    ```
    wget http://archive.apache.org/dist/avro/avro-1.7.5/cpp/avro-cpp-1.7.5.tar.gz
-   tar -zxf avro-cpp-1.7.7.tar.gz
+   tar -zxf avro-cpp-1.7.5.tar.gz
    cd avro-cpp-1.7.5/
    cmake -G "Unix Makefiles"
    sudo make install


### PR DESCRIPTION
Fixed link and path for avrocpp in C++/SDK Linux guide
