### PR TITLE
KAA-685 Minor inaccuracy on C++/SDK-Beaglebone guide

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Beaglebone/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Beaglebone/index.md
@@ -25,7 +25,7 @@ Refer to [the Linux guide]({{root_url}}Programming-guide/Using-Kaa-endpoint-SDKs
 
 1. Install build prerequisites.
 
-        sudo apt-get install cmake build-essentials
+        sudo apt-get install cmake build-essential
 
 1. Download toolchain.
 


### PR DESCRIPTION
Minor inaccuracy on C++/SDK-Beaglebone guide. Wrong build-essential name
