### PR TITLE
Kaa 1241 Minor inaccuracy on C/SDK-QNX-Neutrino guide

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-QNX-Neutrino/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-QNX-Neutrino/index.md
@@ -35,7 +35,7 @@ To install QNX *Software Development Platform (SDP)*, proceed as follows:
 
 1. Install build dependencies.
 
-        sudo apt-get install cmake build-essentials
+        sudo apt-get install cmake build-essential
 
 1. Set the path to the root directory of SDP.
 


### PR DESCRIPTION
Minor inaccuracy on C/SDK-QNX-Neutrino guide. Wrong build-essential name.
