### PR TITLE
KAA-1346: Failed build on MacOSX: Conflict on "htonll"

### DIFF
--- a/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_sock.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/Econais/EC19D/econais_ec19d_sock.h
@@ -35,10 +35,10 @@ typedef sndc_socklen_t kaa_socklen_t;
 
 #define KAA_HTONS(hostshort)        sndc_htons((hostshort))
 #define KAA_HTONL(hostlong)         sndc_htonl((hostlong))
-#define KAA_HTONLL(hostlonglong)    htonll((hostlonglong))
+#define KAA_HTONLL(hostlonglong)    kaa_htonll((hostlonglong))
 
 #define KAA_NTOHS(netshort)     sndc_ntohs((netshort))
 #define KAA_NTOHL(netlong)      sndc_ntohl((netlong))
-#define KAA_NTOHLL(netlonglong) ntohll((netlonglong))
+#define KAA_NTOHLL(netlonglong) kaa_ntohll((netlonglong))
 
 #endif /* ECONAIS_EC19D_SOCK_H_ */

--- a/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/platform/sock.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/cc32xx/platform/sock.h
@@ -79,10 +79,10 @@ typedef socklen_t kaa_socklen_t;
 
 #define KAA_HTONS(hostshort)     htons((hostshort))
 #define KAA_HTONL(hostlong)      htonl((hostlong))
-#define KAA_HTONLL(hostlonglong) htonll((hostlonglong))
+#define KAA_HTONLL(hostlonglong) kaa_htonll((hostlonglong))
 
 #define KAA_NTOHS(netshort)      ntohs((netshort))
 #define KAA_NTOHL(netlong)       ntohl((netlong))
-#define KAA_NTOHLL(netlonglong)  ntohll((netlonglong))
+#define KAA_NTOHLL(netlonglong)  kaa_ntohll((netlonglong))
 
 #endif /* CC32XX_SOCK_H_ */

--- a/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_htonll.c
+++ b/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_htonll.c
@@ -20,7 +20,7 @@
 #define TYP_SMLE 1
 #define TYP_BIGE 2
 
-uint64_t htonll(uint64_t hostlonglong) {
+uint64_t kaa_htonll(uint64_t hostlonglong) {
     static int typ = TYP_INIT;
     unsigned char c;
     union {
@@ -41,7 +41,7 @@ uint64_t htonll(uint64_t hostlonglong) {
     return x.ull;
 }
 
-uint64_t ntohll(uint64_t netlonglong)
+uint64_t kaa_ntohll(uint64_t netlonglong)
 {
-    return htonll(netlonglong);
+    return kaa_htonll(netlonglong);
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_htonll.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/common/kaa_htonll.h
@@ -23,9 +23,9 @@
 extern "C" {
 #endif
 
-uint64_t htonll(uint64_t hostlonglong);
+uint64_t kaa_htonll(uint64_t hostlonglong);
 
-uint64_t ntohll(uint64_t netlonglong);
+uint64_t kaa_ntohll(uint64_t netlonglong);
 
 #ifdef __cplusplus
 }

--- a/client/client-multi/client-c/src/kaa/platform-impl/esp8266/platform/sock.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/esp8266/platform/sock.h
@@ -28,9 +28,9 @@ typedef socklen_t kaa_socklen_t;
 
 #define KAA_HTONS(a)    htons((a))
 #define KAA_HTONL(a)    htonl((a))
-#define KAA_HTONLL(a)   htonll((a))
+#define KAA_HTONLL(a)   kaa_htonll((a))
 
 #define KAA_NTOHS(a)    ntohs((a))
 #define KAA_NTOHL(a)    ntohl((a))
-#define KAA_NTOHLL(a)   ntohll((a))
+#define KAA_NTOHLL(a)   kaa_ntohll((a))
 #endif /* ESP8266_SOCK_H */

--- a/client/client-multi/client-c/src/kaa/platform-impl/posix/platform/sock.h
+++ b/client/client-multi/client-c/src/kaa/platform-impl/posix/platform/sock.h
@@ -37,10 +37,10 @@ typedef socklen_t kaa_socklen_t;
 
 #define KAA_HTONS(hostshort)     htons((hostshort))
 #define KAA_HTONL(hostlong)      htonl((hostlong))
-#define KAA_HTONLL(hostlonglong) htonll((hostlonglong))
+#define KAA_HTONLL(hostlonglong) kaa_htonll((hostlonglong))
 
 #define KAA_NTOHS(netshort)      ntohs((netshort))
 #define KAA_NTOHL(netlong)       ntohl((netlong))
-#define KAA_NTOHLL(netlonglong)  ntohll((netlonglong))
+#define KAA_NTOHLL(netlonglong)  kaa_ntohll((netlonglong))
 
 #endif /* POSIX_SOCK_H_ */


### PR DESCRIPTION
Fix conflict on "htonll" by rename to "kaa_htonll"
Reviewers: @forGGe and @vadimol 
