### PR TITLE
KAA-1347: Failed test 12 on MacOSX

### DIFF
--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -730,13 +730,11 @@ kaa_error_t kaa_platform_protocol_alloc_serialize_client_sync(kaa_platform_proto
 
 ext_tcp_socket_state_t ext_tcp_utils_tcp_socket_check(kaa_fd_t fd, const kaa_sockaddr_t *destination, kaa_socklen_t destination_size)
 {
-    int result_memcmp;
-
     /* Only to avoid compiler's warning */
     (void)destination_size;
 
     if (fd == ACCESS_POINT_SOCKET_FD) {
-        result_memcmp = memcmp(destination->sa_data, DESTINATION_SOCKADDR.sa_data,
+        int result_memcmp = memcmp(destination->sa_data, DESTINATION_SOCKADDR.sa_data,
                 sizeof(DESTINATION_SOCKADDR.sa_data));
         if ((result_memcmp == 0) && (destination->sa_family == DESTINATION_SOCKADDR.sa_family)) {
             if (access_point_test_info.socket_connecting_error_scenario) {

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -730,9 +730,15 @@ kaa_error_t kaa_platform_protocol_alloc_serialize_client_sync(kaa_platform_proto
 
 ext_tcp_socket_state_t ext_tcp_utils_tcp_socket_check(kaa_fd_t fd, const kaa_sockaddr_t *destination, kaa_socklen_t destination_size)
 {
+    int result_memcmp;
+
+    /* Only to avoid compiler's warning */
+    (void)destination_size;
 
     if (fd == ACCESS_POINT_SOCKET_FD) {
-        if(memcmp(destination, &DESTINATION_SOCKADDR,destination_size) == 0) {
+        result_memcmp = memcmp(destination->sa_data, DESTINATION_SOCKADDR.sa_data,
+                sizeof(DESTINATION_SOCKADDR.sa_data));
+        if ((result_memcmp == 0) && (destination->sa_family == DESTINATION_SOCKADDR.sa_family)) {
             if (access_point_test_info.socket_connecting_error_scenario) {
                 return KAA_TCP_SOCK_ERROR;
             } else {
@@ -740,6 +746,7 @@ ext_tcp_socket_state_t ext_tcp_utils_tcp_socket_check(kaa_fd_t fd, const kaa_soc
             }
         }
     }
+
     return KAA_TCP_SOCK_CONNECTED;
 }
 
@@ -795,9 +802,13 @@ ext_tcp_utils_function_return_state_t ext_tcp_utils_getaddrbyhost(kaa_dns_resolv
 
 kaa_error_t ext_tcp_utils_open_tcp_socket(kaa_fd_t *fd, const kaa_sockaddr_t *destination, kaa_socklen_t destination_size)
 {
+    int result_memcmp;
+
     KAA_RETURN_IF_NIL3(fd, destination, destination_size, KAA_ERR_BADPARAM);
 
-    if(memcmp(destination, &DESTINATION_SOCKADDR,destination_size) == 0) {
+    result_memcmp = memcmp(destination->sa_data, DESTINATION_SOCKADDR.sa_data,
+            sizeof(DESTINATION_SOCKADDR.sa_data));
+    if ((result_memcmp == 0) && (destination->sa_family == DESTINATION_SOCKADDR.sa_family)) {
         access_point_test_info.new_socket_created = true;
         *fd = ACCESS_POINT_SOCKET_FD;
         return KAA_ERR_NONE;


### PR DESCRIPTION
Add platform independent sockaddr test
Reviewers: @rasendubi and @forGGe 
