### PR TITLE
KAA-1367: Failed build and linking C++ part on OS X

### DIFF
--- a/client/client-multi/client-cpp/CMakeLists.txt
+++ b/client/client-multi/client-cpp/CMakeLists.txt
@@ -204,6 +204,10 @@ if(NOT MSVC)
    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb")
 endif()
 
+# "no-unused-private-field" is added since in most of cases it is false positive
+list(APPEND KAA_COMPILE_OPTIONS
+                -Wno-unused-private-field)
+
 #Compiler specific flags
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     list(APPEND KAA_COMPILE_OPTIONS 

--- a/client/client-multi/client-cpp/kaa/KaaClient.hpp
+++ b/client/client-multi/client-cpp/kaa/KaaClient.hpp
@@ -45,7 +45,7 @@
 namespace kaa {
 
 class KaaClient : public IKaaClient,
-                  public std::enable_shared_from_this<IKaaClient> {
+                  public std::enable_shared_from_this<KaaClient> {
 public:
     KaaClient(IKaaClientPlatformContextPtr context, IKaaClientStateListenerPtr listener);
 

--- a/client/client-multi/client-cpp/kaa/KaaClientPlatformContext.hpp
+++ b/client/client-multi/client-cpp/kaa/KaaClientPlatformContext.hpp
@@ -68,7 +68,7 @@ public:
     KaaClientPlatformContext(KaaClientPlatformContext&& properties) = delete;
     KaaClientPlatformContext& operator=(KaaClientPlatformContext&& properties) = delete;
 
-    ~KaaClientPlatformContext() = default;
+    ~KaaClientPlatformContext() noexcept = default;
 
 private:
     KaaClientProperties    properties_;

--- a/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
+++ b/client/client-multi/client-cpp/kaa/common/exception/KaaException.hpp
@@ -67,7 +67,7 @@ public:
         return message_.c_str();
     }
 
-    virtual ~KaaException() = default;
+    virtual ~KaaException() noexcept = default;
 
 private:
     std::string message_;

--- a/client/client-multi/client-cpp/kaa/configuration/ConfigurationTransport.hpp
+++ b/client/client-multi/client-cpp/kaa/configuration/ConfigurationTransport.hpp
@@ -50,7 +50,7 @@ public:
         configurationProcessor_ = processor;
     }
 
-    virtual ~ConfigurationTransport() noexcept {};
+    virtual ~ConfigurationTransport() noexcept {}
 
 private:
     IConfigurationProcessor        *configurationProcessor_;

--- a/client/client-multi/client-cpp/kaa/configuration/ConfigurationTransport.hpp
+++ b/client/client-multi/client-cpp/kaa/configuration/ConfigurationTransport.hpp
@@ -50,6 +50,8 @@ public:
         configurationProcessor_ = processor;
     }
 
+    virtual ~ConfigurationTransport() noexcept {};
+
 private:
     IConfigurationProcessor        *configurationProcessor_;
     IConfigurationHashContainer    *hashContainer_;

--- a/client/client-multi/client-cpp/kaa/configuration/manager/ConfigurationManager.hpp
+++ b/client/client-multi/client-cpp/kaa/configuration/manager/ConfigurationManager.hpp
@@ -70,7 +70,7 @@ public:
         return configurationHash_;
     }
 
-    virtual ~ConfigurationManager() noexcept {};
+    virtual ~ConfigurationManager() noexcept {}
 
 private:
     void updateConfiguration(const std::uint8_t* data, const std::uint32_t dataSize);

--- a/client/client-multi/client-cpp/kaa/configuration/manager/ConfigurationManager.hpp
+++ b/client/client-multi/client-cpp/kaa/configuration/manager/ConfigurationManager.hpp
@@ -70,6 +70,8 @@ public:
         return configurationHash_;
     }
 
+    virtual ~ConfigurationManager() noexcept {};
+
 private:
     void updateConfiguration(const std::uint8_t* data, const std::uint32_t dataSize);
     void loadConfiguration();

--- a/client/client-multi/client-cpp/kaa/event/EventManager.hpp
+++ b/client/client-multi/client-cpp/kaa/event/EventManager.hpp
@@ -70,6 +70,7 @@ public:
 
     virtual void setTransport(EventTransport *transport);
 
+    using AbstractTransactable::beginTransaction;
     virtual TransactionIdPtr beginTransaction()
     {
         return AbstractTransactable::beginTransaction(context_);
@@ -77,6 +78,7 @@ public:
 
     virtual void commit(TransactionIdPtr trxId, IKaaClientContext &context_);
 
+    using AbstractTransactable::rollback;
     virtual void rollback(TransactionIdPtr trxId)
     {
         AbstractTransactable::rollback(trxId, context_);


### PR DESCRIPTION
Fix compiler warnings that are generated while tests compilation;
Fix static casting error;
Compilation errors fixes;

Reviewers: @forGGe and @rasendubi 
