### PR TITLE
KAA-1440: [Objective-C SDK] Add noConnectivityRetryPeriod property to FailoverStrategy protocol.

### DIFF
--- a/client/client-multi/client-objective-c/Kaa/channel/failover/strategies/DefaultFailoverStrategy.m
+++ b/client/client-multi/client-objective-c/Kaa/channel/failover/strategies/DefaultFailoverStrategy.m
@@ -26,7 +26,6 @@ static const int64_t kDefaultTimeUnit = TIME_UNIT_SECONDS;
 
 @interface DefaultFailoverStrategy ()
 
-@property (nonatomic) int64_t noConnectivityRetryPeriod;
 
 @end
 
@@ -34,6 +33,7 @@ static const int64_t kDefaultTimeUnit = TIME_UNIT_SECONDS;
 
 @synthesize bootstrapServersRetryPeriod = _bootstrapServersRetryPeriod;
 @synthesize operationsServersRetryPeriod = _operationsServersRetryPeriod;
+@synthesize noConnectivityRetryPeriod = _noConnectivityRetryPeriod;
 @synthesize timeUnit = _timeUnit;
 
 - (instancetype)init {

--- a/client/client-multi/client-objective-c/Kaa/channel/failover/strategies/FailoverStrategy.h
+++ b/client/client-multi/client-objective-c/Kaa/channel/failover/strategies/FailoverStrategy.h
@@ -29,6 +29,7 @@
 
 @property (nonatomic, readonly) int64_t bootstrapServersRetryPeriod;
 @property (nonatomic, readonly) int64_t operationsServersRetryPeriod;
+@property (nonatomic, readonly) int64_t noConnectivityRetryPeriod;
 @property (nonatomic, readonly) TimeUnit timeUnit;
 
 /**


### PR DESCRIPTION
http://jira.kaaproject.org/browse/KAA-1440
