### PR TITLE
KAA-1444: Fix method editUser() in AdminUI

### DIFF
--- a/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/data/DataSource.java
+++ b/server/node/src/main/java/org/kaaproject/kaa/server/admin/client/mvp/data/DataSource.java
@@ -30,6 +30,7 @@ import org.kaaproject.kaa.common.dto.EndpointProfileDto;
 import org.kaaproject.kaa.common.dto.EndpointProfileSchemaDto;
 import org.kaaproject.kaa.common.dto.EndpointProfilesPageDto;
 import org.kaaproject.kaa.common.dto.EndpointUserConfigurationDto;
+import org.kaaproject.kaa.common.dto.KaaAuthorityDto;
 import org.kaaproject.kaa.common.dto.NotificationDto;
 import org.kaaproject.kaa.common.dto.NotificationSchemaDto;
 import org.kaaproject.kaa.common.dto.ProfileFilterDto;
@@ -60,6 +61,7 @@ import org.kaaproject.kaa.common.dto.file.FileData;
 import org.kaaproject.kaa.common.dto.logs.LogAppenderDto;
 import org.kaaproject.kaa.common.dto.logs.LogSchemaDto;
 import org.kaaproject.kaa.common.dto.user.UserVerifierDto;
+import org.kaaproject.kaa.server.admin.client.KaaAdmin;
 import org.kaaproject.kaa.server.admin.client.mvp.event.data.DataEvent;
 import org.kaaproject.kaa.server.admin.shared.config.ConfigurationRecordFormDto;
 import org.kaaproject.kaa.server.admin.shared.config.ConfigurationRecordViewDto;
@@ -436,7 +438,9 @@ public class DataSource {
         userRpcService.editUser(user, new DataCallback<UserDto>(callback) {
             @Override
             protected void onResult(UserDto result) {
-                refreshUsers();
+                if (KaaAdmin.getAuthInfo().getAuthority() == KaaAuthorityDto.TENANT_ADMIN) {
+                    refreshUsers();
+                }
             }
         });
     }


### PR DESCRIPTION
During creation of tenant administrator on behalf of KAA_ADMIN, calling method getUsers()(only for TENANT_ADMIN) from method editUser() in AdminUI.
