### PR TITLE
KAA-1432: Fixed Spring context cleanup in KaaNodeServerLauncherIT

### DIFF
--- a/server/node/src/test/java/org/kaaproject/kaa/server/node/KaaNodeServerLauncherIT.java
+++ b/server/node/src/test/java/org/kaaproject/kaa/server/node/KaaNodeServerLauncherIT.java
@@ -16,6 +16,16 @@
 
 package org.kaaproject.kaa.server.node;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingCluster;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -27,13 +37,18 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.kaaproject.kaa.common.avro.AvroByteArrayConverter;
 import org.kaaproject.kaa.server.common.nosql.mongo.dao.MongoDBTestRunner;
 import org.kaaproject.kaa.server.common.thrift.KaaThriftService;
 import org.kaaproject.kaa.server.common.thrift.gen.node.KaaNodeThriftService;
+import org.kaaproject.kaa.server.common.utils.KaaUncaughtExceptionHandler;
+import org.kaaproject.kaa.server.common.zk.gen.OperationsNodeInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 
-import java.util.concurrent.TimeoutException;
+import com.google.common.io.Closeables;
 
 /**
  * The Class KaaNodeServerLauncherIT.
@@ -43,8 +58,7 @@ public class KaaNodeServerLauncherIT {
   /**
    * The Constant LOG.
    */
-  private static final Logger LOG = LoggerFactory
-      .getLogger(KaaNodeServerLauncherIT.class);
+  private static final Logger LOG = LoggerFactory.getLogger(KaaNodeServerLauncherIT.class);
 
   /**
    * The Constant HOST.
@@ -55,6 +69,12 @@ public class KaaNodeServerLauncherIT {
    * The Constant PORT.
    */
   private static final int PORT = 10090;
+
+  private static final String OPERATIONS_SERVER_NODE_PATH = "/operationsServerNodes";
+  private static final AvroByteArrayConverter<OperationsNodeInfo> OPERATIONS_NODE_INFO_CONVERTER =
+      new AvroByteArrayConverter<>(OperationsNodeInfo.class);
+  private static final int KAA_NODE_START_TIMEOUT_SEC = 60;
+  private static final int KAA_NODE_STOP_TIMEOUT_SEC = 30;
 
   /**
    * Inits the.
@@ -88,46 +108,59 @@ public class KaaNodeServerLauncherIT {
     TTransport transport = null;
     Thread kaaNodeServerLauncherThread = null;
     KaaNodeThriftService.Client client = null;
+    CuratorFramework zkClient = null;
+    CountDownLatch latch = new CountDownLatch(1);
+    boolean kaaNodeStarted = false;
+    TestKaaNodeLauncher launcher = new TestKaaNodeLauncher();
     try {
       zkCluster = new TestingCluster(new InstanceSpec(null, 2185, -1, -1, true, -1, -1, -1));
       zkCluster.start();
+      zkClient =
+          CuratorFrameworkFactory.newClient(zkCluster.getConnectString(), new RetryOneTime(100));
+      zkClient.start();
 
-      kaaNodeServerLauncherThread = new Thread(new Runnable() {
-        @SuppressWarnings("static-access")
-        @Override
-        public void run() {
-          LOG.info("Starting Kaa Node Server ...");
-          new KaaNodeApplication(new String[]{}, new String[]{}).main(new String[]{"common-test-context.xml", "kaa-node-test.properties"});
-          LOG.info("Kaa Node Server Stopped");
-        }
-      });
-
+      kaaNodeServerLauncherThread = new Thread(launcher);
       kaaNodeServerLauncherThread.start();
 
-      Thread.sleep(15000);
+      OperationsNodeStartupListener operationsNodeStartupListener =
+          new OperationsNodeStartupListener();
+      zkClient.getCuratorListenable().addListener(operationsNodeStartupListener);
+      zkClient.getChildren().inBackground(latch).forPath(OPERATIONS_SERVER_NODE_PATH);
+      // Wait for operations service to start
+      kaaNodeStarted = latch.await(KAA_NODE_START_TIMEOUT_SEC, TimeUnit.SECONDS);
+      zkClient.getCuratorListenable().removeListener(operationsNodeStartupListener);
 
       transport = new TSocket(HOST, PORT);
       TProtocol protocol = new TBinaryProtocol(transport);
-      TMultiplexedProtocol mp = new TMultiplexedProtocol(protocol, KaaThriftService.KAA_NODE_SERVICE.getServiceName());
+      TMultiplexedProtocol mp =
+          new TMultiplexedProtocol(protocol, KaaThriftService.KAA_NODE_SERVICE.getServiceName());
       client = new KaaNodeThriftService.Client(mp);
       transport.open();
       client.shutdown();
 
     } finally {
+      boolean shutdownFailed = false;
+      Closeables.close(zkClient, true);
       if (transport != null && transport.isOpen()) {
-        try {
-          transport.close();
-        } catch (Exception e) {
-        }
+        Closeables.close(transport, true);
       }
       if (kaaNodeServerLauncherThread != null) {
         kaaNodeServerLauncherThread.join(30000);
-        if (kaaNodeServerLauncherThread.isAlive()) {
-          throw new TimeoutException("Timeout (30 sec) occured while waiting kaa node server shutdown thread!");
+        shutdownFailed = kaaNodeServerLauncherThread.isAlive();
+      }
+      Closeables.close(zkCluster, true);
+      if (launcher != null) {
+        ConfigurableApplicationContext appContext = launcher.getApplicationContext();
+        if (appContext.isActive()) {
+          Closeables.close(appContext, true);
         }
       }
-      if (zkCluster != null) {
-        zkCluster.close();
+      if (!kaaNodeStarted) {
+        throw new TimeoutException("Timeout (" + KAA_NODE_START_TIMEOUT_SEC
+            + " sec) occured while waiting kaa node server to start!");
+      } else if (shutdownFailed) {
+        throw new TimeoutException("Timeout (" + KAA_NODE_STOP_TIMEOUT_SEC
+            + " sec) occured while waiting kaa node server shutdown thread!");
       }
     }
   }
@@ -173,10 +206,81 @@ public class KaaNodeServerLauncherIT {
       if (kaaNodeServerLauncherThread != null) {
         kaaNodeServerLauncherThread.join(30000);
         if (kaaNodeServerLauncherThread.isAlive()) {
-          throw new TimeoutException("Timeout (30 sec) occured while waiting kaa node server shutdown thread!");
+          throw new TimeoutException(
+              "Timeout (30 sec) occured while waiting kaa node server shutdown thread!");
         }
       }
     }
+  }
+
+  private class OperationsNodeStartupListener implements CuratorListener {
+    @Override
+    public void eventReceived(CuratorFramework client, CuratorEvent event) throws Exception {
+      if (event.getType() == CuratorEventType.CHILDREN) {
+        if (event.getChildren().isEmpty()) {
+          client.getChildren().inBackground(event.getContext()).forPath(event.getPath());
+        } else {
+          String path = event.getPath() + "/" + event.getChildren().get(0);
+          LOG.info("Operations Node registered in ZK. Waiting for transports configration");
+          client.getData().inBackground(event.getContext()).forPath(path);
+        }
+      } else if (event.getType() == CuratorEventType.GET_DATA) {
+        if (event.getData() == null) {
+          client.getData().inBackground(event.getContext()).forPath(event.getPath());
+        } else {
+          OperationsNodeInfo nodeInfo =
+              OPERATIONS_NODE_INFO_CONVERTER.fromByteArray(event.getData());
+          boolean isTransportInitialized = !nodeInfo.getTransports().isEmpty();
+
+          if (isTransportInitialized) {
+            LOG.info("Operations Node updated tarnsports configuration in ZK");
+            ((CountDownLatch) event.getContext()).countDown();
+          } else {
+            client.getData().inBackground(event.getContext()).forPath(event.getPath());
+          }
+        }
+      }
+    }
+  }
+
+  private static class TestKaaNodeApplication extends KaaNodeApplication {
+    private static final String[] DEFAULT_APPLICATION_CONTEXT_XMLS =
+        new String[] {"kaaNodeContext.xml"};
+
+    private static final String[] DEFAULT_APPLICATION_CONFIGURATION_FILES =
+        new String[] {"kaa-node.properties", "sql-dao.properties", "nosql-dao.properties"};
+    ConfigurableApplicationContext applicationContext;
+
+    public TestKaaNodeApplication() {
+      super(DEFAULT_APPLICATION_CONTEXT_XMLS, DEFAULT_APPLICATION_CONFIGURATION_FILES);
+    }
+
+    @Override
+    protected void init(ApplicationContext applicationContext) {
+      this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+      super.init(applicationContext);
+    }
+  }
+
+  private class TestKaaNodeLauncher implements Runnable {
+    private TestKaaNodeApplication app;
+
+    @Override
+    public void run() {
+      LOG.info("Starting Kaa Node Server ...");
+      Thread.setDefaultUncaughtExceptionHandler(new KaaUncaughtExceptionHandler());
+      app = new TestKaaNodeApplication();
+      app.startAndWait(new String[] {"common-test-context.xml", "kaa-node-test.properties"});
+      LOG.info("Kaa Node Server Stopped");
+    }
+
+    private ConfigurableApplicationContext getApplicationContext() {
+      if (app != null) {
+        return app.applicationContext;
+      }
+      return null;
+    }
+
   }
 
 }


### PR DESCRIPTION
Fixed common issue with failing integration tests with error _Failed to load ApplicationContext_.
The main issue was in _KaaNodeServerLauncherIT_. There was too small timeout for Kaa node application to start. And if timeout exception has been thrown or any other error occurred we have to correctly close the ApplicationContext.
