### PR TITLE
KAA-1366: Add links to Nix guide

### DIFF
--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Linux/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C++/SDK-Linux/index.md
@@ -110,7 +110,7 @@ If you want to build the endpoint SDK quickly or build and run Kaa C/C++ demo ap
 **NOTE:**
 If you would like to run a compiled binary on some other host, you should have all third-party libraries like boost, etc. preinstalled.
 
-### Build in nix shell
+### Build in Nix shell
 [Nix](https://nixos.org/nix) is a package manager which is used to manage Kaa C and C++ SDKs build environment for CI purposes. You can use it to build Kaa C++ SDK quickly.
 Just install Nix on your system and execute the following command from the [root directory](https://github.com/kaaproject/kaa/tree/master/client/client-multi/client-cpp) of Kaa C++ SDK:
 
@@ -119,6 +119,7 @@ nix-shell
 ```
 
 Nix will download and compile all SDK dependencies and prepare your environment for development.
+For more details on using Nix in C and C++ SDKs refer to [Nix guide]({{root_url}}Customization-guide/Nix-guide/).
 
 ## Minimal example
 This section describes application development with Kaa C++ SDK.

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/index.md
@@ -64,6 +64,12 @@ During compilation, Kaa C SDK and the derived applications might require:
  - A compiler for the chosen taget platform, such as `arm-none-eabi` for bare metal ARM targets.
  - Vendor SDK, e.g. TI SDK for the CC3200 processor.
 
+### Build in Nix shell
+[Nix](https://nixos.org/nix) is a package manager which is used to manage Kaa C and C++ SDKs build environment for CI purposes.
+You can use it to build Kaa C SDK quickly.
+
+For more details on using Nix in C and C++ SDKs refer to [Nix guide]({{root_url}}Customization-guide/Nix-guide/).
+
 ### Build configuration
 
 Build configuration is performed on the Makefile file generation stage.


### PR DESCRIPTION
The links were removed after cleaning up broken links. Now we have the
guide, so it's good to guide people to it.
