### PR TITLE
KAA-1535: Fix passing custom parameters to jekyll

### DIFF
--- a/gh-pages-stub/_scripts/tst_deploy.sh
+++ b/gh-pages-stub/_scripts/tst_deploy.sh
@@ -217,7 +217,7 @@ test_docs() {
 if [ x"deploy" = x"$1" ]; then
   deploy_docs
 elif [ -d doc ]; then
-  test_docs
+  test_docs "$@"
 else
   echo "Nothing to do"
 fi


### PR DESCRIPTION
This fixes `./test-gh-pages.sh --host=xxx`.

/cc @vadimol 
