### PR TITLE
KAA-1536: Toggle mobile sidebar menu issue

### DIFF
--- a/gh-pages-stub/public/js/scripts.js
+++ b/gh-pages-stub/public/js/scripts.js
@@ -81,11 +81,10 @@ var DOM = (function () {
 $(document).ready(function(){/* off-canvas sidebar toggle */
 
 $('[data-toggle=offcanvas]').click(function() {
-  	$(this).toggleClass('visible-xs text-center');
     $(this).find('i').toggleClass('glyphicon-chevron-right glyphicon-chevron-left');
     $('.row-offcanvas').toggleClass('active');
-    $('#lg-menu').toggleClass('hidden-xs').toggleClass('visible-xs');
-    $('#xs-menu').toggleClass('visible-xs').toggleClass('hidden-xs');
+    $('#lg-menu').toggleClass('hidden-xs').toggleClass('visible');
+    $('#xs-menu').toggleClass('visible-xs').toggleClass('hidden');
     $('#btnShow').toggle();
 });
 });


### PR DESCRIPTION
When open documentation menu in small resolution and then resize into big one, menu suddenly disappears.
