### PR TITLE
KAA-1308:Replaced KAA_UNITTESTS_COMPILE with BUILD_TESTING

### DIFF
--- a/client/client-multi/client-c/CMakeLists.txt
+++ b/client/client-multi/client-c/CMakeLists.txt
@@ -58,14 +58,14 @@
 #
 #	Default: `posix`
 #
-#	- `KAA_UNITETESTS_COMPILE` - compile unit tests.
+#	- `BUILD_TESTING` - compile unit tests.
 #
 #	Values:
 #
 #	- `ON`
 #	- `OFF`
 #
-#	Default: `OFF`
+#	Default: `ON`
 #
 #	Note: requires [cmocka](https://cmocka.org/) test framework to be installed.
 

--- a/client/client-multi/client-c/build.sh
+++ b/client/client-multi/client-c/build.sh
@@ -34,7 +34,7 @@ fi
 prepare_build() {
     mkdir -p build-posix
     cd build-posix
-    cmake -DCMAKE_BUILD_TYPE=Debug -DKAA_MAX_LOG_LEVEL=$MAX_LOG_LEVEL -DKAA_UNITTESTS_COMPILE=1 -DKAA_COLLECT_COVERAGE=1 -DKAA_ENCRYPTION=1 .. -DCMAKE_C_FLAGS="-Werror"
+    cmake -DCMAKE_BUILD_TYPE=Debug -DKAA_MAX_LOG_LEVEL=$MAX_LOG_LEVEL -DKAA_COLLECT_COVERAGE=1 -DKAA_ENCRYPTION=1 .. -DCMAKE_C_FLAGS="-Werror"
     cd ..
 }
 

--- a/client/client-multi/client-c/listfiles/UnitTest.cmake
+++ b/client/client-multi/client-c/listfiles/UnitTest.cmake
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 
-if(KAA_UNITTESTS_COMPILE)
+include(CTest)
+
+if(BUILD_TESTING)
     find_package(cmocka REQUIRED)
     find_program(MEMORYCHECK_COMMAND valgrind)
     set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-reachable=yes --trace-children=yes -v")
 
-    include(CTest)
     include(CMakeParseArguments)
 endif()
 
@@ -37,7 +38,7 @@ endif()
 #                   [DEPENDS list_of_dependencies...]
 #                   [INC_DIRS list_of_include_directories...])
 function(kaa_add_unit_test)
-    if(KAA_UNITTESTS_COMPILE)
+    if(BUILD_TESTING)
         cmake_parse_arguments(
             UNIT_TEST
             ""

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Beaglebone/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Beaglebone/index.md
@@ -36,5 +36,5 @@ Now, the toolchain is installed, and it is time to create Kaa application.
 Since BeagleBone (BeagleBone Black) is running Linux, you can refer to [the Linux guide]({{root_url}}Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/#c-sdk-build) for the detailed process of application creation.
 However, remember, you must specify [the CMake C Compiler](http://www.vtk.org/Wiki/CMake_Cross_Compiling#Setting_up_the_system_and_toolchain) when compiling your Kaa application for BeagleBone:
 
-        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_C_COMPILER="$TOOLCHAIN_PATH/arm-linux-gnueabihf-gcc" ..
+        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_C_COMPILER="$TOOLCHAIN_PATH/arm-linux-gnueabihf-gcc" -DBUILD_TESTING=OFF ..
         make

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-ESP8266/index.md
@@ -353,6 +353,7 @@ To invoke CMake, proceed as follows:
         cmake .. \
             -DCMAKE_TOOLCHAIN_FILE=../kaa/toolchains/esp8266.cmake \
             -DKAA_PLATFORM=esp8266 \
+            -DBUILD_TESTING=OFF \
             -DCMAKE_BUILD_TYPE=MinSizeRel \
             -DKAA_MAX_LOG_LEVEL=3
         make

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Edison/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Edison/index.md
@@ -44,9 +44,8 @@ Now, dependencies are installed and it is time to create Kaa application.
 Since Edison is running Linux, you can refer to [the Linux guide]({{root_url}}Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/#c-sdk-build) for detailed process of application creation.
 But remember, you must specify correct compiler when compiling your Kaa application for Intel Edison:
 
-        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_TOOLCHAIN_FILE=PATH_TO_KAA_SDK/toolchains/edison.cmake ..
+        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_TOOLCHAIN_FILE=PATH_TO_KAA_SDK/toolchains/edison.cmake -DBUILD_TESTING=OFF ..
         make 
 
-Where `PATH_TO_KAA_SDK` is path to Kaa C SDK relative to the `build` directory.
 For more details on how to build, upload and run your application on Edison board, you may refer to official [user guide](https://software.intel.com/en-us/intel-edison-board-user-guide).
 

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/index.md
@@ -172,10 +172,13 @@ Before continuing, make sure that all [dependencies](#dependencies) are installe
 
 1. Configure the build via CMake and run make.
 
-        cmake -DKAA_MAX_LOG_LEVEL=3 ..
+        cmake -DKAA_MAX_LOG_LEVEL=3 -DBUILD_TESTING=OFF ..
         make
 
     `KAA_MAX_LOG_LEVEL` [parameter]({{root_url}}/Programming-guide/Using-Kaa-endpoint-SDKs/C) is used here to decrease log level which is set by default to eliminate output pollution.
+
+    `BUILD_TESTING` is ON by defaulf. Switch it to OFF to prevent running tests.
+
     Now run your application.
 
         ./kaa-app

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-QNX-Neutrino/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-QNX-Neutrino/index.md
@@ -77,7 +77,7 @@ Kaa C SDK already provides the toolchain file for QNX as shown below.
 ```bash
 mkdir -p build
 cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/qnx.cmake ..
+cmake -DCMAKE_TOOLCHAIN_FILE=../toolchains/qnx.cmake -DBUILD_TESTING=OFF ..
 make
 ````
 

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-RPi/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-RPi/index.md
@@ -40,5 +40,5 @@ Now, dependencies are installed and it is time to create Kaa application.
 Since Raspberry is running Linux, you can refer to [the Linux guide]({{root_url}}Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-Linux/#c-sdk-build) for detailed process of application creation.
 But remember, you must specify correct compiler name when compiling your Kaa application for Raspberry Pi:
 
-        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_C_COMPILER=$ARMLINUX_GCC ..
+        cmake -DKAA_MAX_LOG_LEVEL=3 -DCMAKE_C_COMPILER=$ARMLINUX_GCC -DBUILD_TESTING=OFF ..
         make

--- a/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-TI-CC3200/index.md
+++ b/doc/Programming-guide/Using-Kaa-endpoint-SDKs/C/SDK-TI-CC3200/index.md
@@ -124,7 +124,7 @@ Change directory to where SDK was unpacked and execute the following:
 ```
 mkdir -p build
 cd build
-cmake -DKAA_PLATFORM=cc32xx -DCMAKE_TOOLCHAIN_FILE=../toolchains/cc32xx.cmake ..
+cmake -DKAA_PLATFORM=cc32xx -DCMAKE_TOOLCHAIN_FILE=../toolchains/cc32xx.cmake -DBUILD_TESTING=OFF ..
 make
 ```
 
@@ -137,7 +137,7 @@ Open the Cygwin terminal and execute the following:
 ```
 mkdir -p build
 cd build
-cmake.exe -G "Unix Makefiles" -DKAA_PLATFORM=cc32xx -DCC32XX_TOOLCHAIN_PATH=c:/cygwin/opt/kaa -DCMAKE_TOOLCHAIN_FILE=../toolchains/cc32xx.cmake ..
+cmake.exe -G "Unix Makefiles" -DKAA_PLATFORM=cc32xx -DCC32XX_TOOLCHAIN_PATH=c:/cygwin/opt/kaa -DCMAKE_TOOLCHAIN_FILE=../toolchains/cc32xx.cmake -DBUILD_TESTING=OFF ..
 make
 ```
 

--- a/doc/Programming-guide/Your-first-Kaa-application/index.md
+++ b/doc/Programming-guide/Your-first-Kaa-application/index.md
@@ -210,7 +210,7 @@ To do this, run the following commands in the terminal.
 
 		mkdir build
 		cd build
-		cmake ..
+		cmake -DBUILD_TESTING=OFF ..
 		make
 
 6. Check that the demo application executable file is present in the build directory.
@@ -905,7 +905,7 @@ To launch your C application:
 This will clean up the mess that can occur when debug logs are enabled.
 
         cd build
-        cmake -DKAA_MAX_LOG_LEVEL=3 ..
+        cmake -DKAA_MAX_LOG_LEVEL=3 -DBUILD_TESTING=OFF ..
         make
 
 2. Launch the executable file.

--- a/nix/kaa-client-c/default.nix
+++ b/nix/kaa-client-c/default.nix
@@ -81,17 +81,17 @@ let
         __propagate:;
       ''
       + target posixSupport "posix"
-              "${lib.optionalString testSupport ''-DCMAKE_BUILD_TYPE=Debug -DKAA_UNITTESTS_COMPILE=on -DKAA_COLLECT_COVERAGE=1''}"
+              "${if testSupport then ''-DCMAKE_BUILD_TYPE=Debug -DKAA_COLLECT_COVERAGE=1'' else ''-DBUILD_TESTING=OFF''}"
       + target posixSupport "nologs"
-              "${lib.optionalString testSupport ''-DKAA_UNITTESTS_COMPILE=on''} -DKAA_MAX_LOG_LEVEL=0"
+              "${lib.optionalString (!testSupport) ''-DBUILD_TESTING=OFF''} -DKAA_MAX_LOG_LEVEL=0"
       + target clangSupport "clang"
-              "${lib.optionalString testSupport ''-DKAA_UNITTESTS_COMPILE=on''} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+              "${lib.optionalString (!testSupport) ''-DBUILD_TESTING=OFF''} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
       + target cc3200Support "cc3200"
-              "-DKAA_PLATFORM=cc32xx -DCMAKE_TOOLCHAIN_FILE=toolchains/cc32xx.cmake -DCC32XX_SDK='${cc3200-sdk}/lib/cc3200-sdk/cc3200-sdk' -DCC32XX_TOOLCHAIN_PATH='${gcc-arm-embedded}'"
+              "-DKAA_PLATFORM=cc32xx -DCMAKE_TOOLCHAIN_FILE=toolchains/cc32xx.cmake -DBUILD_TESTING=OFF -DCC32XX_SDK='${cc3200-sdk}/lib/cc3200-sdk/cc3200-sdk' -DCC32XX_TOOLCHAIN_PATH='${gcc-arm-embedded}'"
       + target esp8266Support "esp8266"
-              "-DKAA_PLATFORM=esp8266 -DCMAKE_TOOLCHAIN_FILE=toolchains/esp8266.cmake -DESP8266_TOOLCHAIN_PATH='${gcc-xtensa-lx106}' -DESP8266_SDK_PATH='${esp8266-rtos-sdk}/lib/esp8266-rtos-sdk'"
+              "-DKAA_PLATFORM=esp8266 -DCMAKE_TOOLCHAIN_FILE=toolchains/esp8266.cmake -DBUILD_TESTING=OFF -DESP8266_TOOLCHAIN_PATH='${gcc-xtensa-lx106}' -DESP8266_SDK_PATH='${esp8266-rtos-sdk}/lib/esp8266-rtos-sdk'"
       + target raspberrypiSupport "rpi"
-              "-DCMAKE_TOOLCHAIN_FILE=toolchains/rpi.cmake";
+              "-DCMAKE_TOOLCHAIN_FILE=toolchains/rpi.cmake -DBUILD_TESTING=OFF";
     };
 in stdenv.mkDerivation {
   name = "kaa-client-c";


### PR DESCRIPTION
KAA_UNITTESTS_COMPILE was replased by built-in cmake BUILD_TESTING variable.
Docs and nix configs were updated, because BUILD_TESTING is ON by default.