### PR TITLE
KAA-1640: OracleNoSqlLogAppenderTest fails on Jenkins [master]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@ Copyright 2014-2016 CyberVision, Inc.
         <javax.el>2.2.4</javax.el>
         <org.glassfish.web>2.2.6</org.glassfish.web>
         <hibernate-validator>5.2.4.Final</hibernate-validator>
+        <sleepycat.je.version>7.0.6</sleepycat.je.version>
     </properties>
 
     <modules>
@@ -1091,6 +1092,14 @@ Copyright 2014-2016 CyberVision, Inc.
                 <scope>test</scope>
             </dependency>
             <dependency>
+              <!-- a test BerkleyDB Java Edition dependency for com.oracle.kv:kvstore 
+                artifact. See http://www.oracle.com/technetwork/products/berkeleydb/downloads/index-098622.html -->
+              <groupId>com.sleepycat</groupId>
+              <artifactId>je</artifactId>
+              <version>${sleepycat.je.version}</version>
+              <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>commons-dbcp</groupId>
                 <artifactId>commons-dbcp</artifactId>
                 <version>${commons.dbcp.version}</version>
@@ -1430,6 +1439,12 @@ Copyright 2014-2016 CyberVision, Inc.
         <repository>
             <id>twitter-twttr</id>
             <url>http://maven.twttr.com/</url>
+        </repository>
+        <repository>        
+          <id>oracleReleases</id>
+          <name>Oracle Released Java Packages</name>
+          <url>http://download.oracle.com/maven</url>
+          <layout>default</layout>
         </repository>
         <repository>
             <id>repository.kaaproject</id>

--- a/server/appenders/oracle-nosql-appender/pom.xml
+++ b/server/appenders/oracle-nosql-appender/pom.xml
@@ -63,7 +63,11 @@
             <groupId>com.oracle.kv</groupId>
             <artifactId>kvstore</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
+        <dependency>
+          <groupId>com.sleepycat</groupId>
+          <artifactId>je</artifactId>
+        </dependency>     
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Added _com.sleepycat:je_ test dependency to resolve _NoClassDefFound_ exception.
The artifact is fetched from [Oracle maven repository](http://download.oracle.com/maven) because no compatible BerkleyDB version found in maven central repository or other existing configured repositories in the root POM file.