### PR TITLE
KAA-1740: Fix cppcheck errors

### DIFF
--- a/client/client-multi/client-c/src/extensions/user/test/test_kaa_user.c
+++ b/client/client-multi/client-c/src/extensions/user/test/test_kaa_user.c
@@ -145,6 +145,8 @@ void test_specified_user_verifier(void **state)
     buf_cursor += kaa_aligned_size_get(strlen(USER_VERIFIER));
 
     kaa_platform_message_writer_destroy(writer);
+
+    (void)buf_cursor;
 }
 
 void test_success_response(void **state)

--- a/client/client-multi/client-c/src/kaa/kaa_status.c
+++ b/client/client-multi/client-c/src/kaa/kaa_status.c
@@ -76,11 +76,10 @@ kaa_error_t kaa_status_create(kaa_status_t ** kaa_status_p)
     KAA_RETURN_IF_NIL(kaa_status->topics, KAA_ERR_NOMEM);
 
     char *  read_buf = NULL;
-    char *  read_buf_head = NULL;
     size_t  read_size = 0;
     bool    needs_deallocation = false;
     ext_status_read(&read_buf, &read_size, &needs_deallocation);
-    read_buf_head = read_buf;
+    char *read_buf_head = read_buf;
 
     if (read_size >= KAA_STATUS_STATIC_SIZE + sizeof(size_t)) {
         READ_BUFFER(read_buf, &kaa_status->is_registered, sizeof(kaa_status->is_registered));

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c
@@ -160,8 +160,8 @@ void test_create_kaa_tcp_channel(void **state)
     (void)state;
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id bootstrap_services[] = {KAA_EXTENSION_BOOTSTRAP};
 
@@ -210,8 +210,8 @@ void test_set_access_point_full_success_bootstrap(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id bootstrap_services[] = {KAA_EXTENSION_BOOTSTRAP};
 
@@ -238,8 +238,8 @@ void test_set_access_point_connecting_error(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id bootstrap_services[] = {KAA_EXTENSION_BOOTSTRAP};
 
@@ -280,8 +280,8 @@ void test_set_access_point_io_error(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id bootstrap_services[] = {KAA_EXTENSION_BOOTSTRAP};
 
@@ -347,8 +347,8 @@ void test_bootstrap_sync_success(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id bootstrap_services[] = {KAA_EXTENSION_BOOTSTRAP};
 

--- a/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c
+++ b/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c
@@ -139,12 +139,12 @@ static uint8_t CONNECTION_DATA[]   = { 0x00, 0x00, 0x01, 0x26, 0x30, 0x82, 0x01,
                                     0x00, 0x01, 0x00, 0x00, 0x00, 0x0C, 0x31, 0x39,
                                     0x32, 0x2E, 0x31, 0x36, 0x38, 0x2E, 0x37, 0x37,
                                     0x2E, 0x32, 0x00, 0x00, 0x26, 0xA0};
-                                    
-                                    
+
+
 #ifdef KAA_ENCRYPTION
-                             
-static uint8_t KAASYNC_OP_SERV_ENCRYPTED[] = { 
-    0xF0, 0x1C, 0x00, 0x06,  'K',  'a',  'a',  't',  'c',  'p', 0x01, 0x00, 0x00, 0x15, 0x34, 
+
+static uint8_t KAASYNC_OP_SERV_ENCRYPTED[] = {
+    0xF0, 0x1C, 0x00, 0x06,  'K',  'a',  'a',  't',  'c',  'p', 0x01, 0x00, 0x00, 0x15, 0x34,
     0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
@@ -155,8 +155,8 @@ static uint8_t KAASYNC_OP_SERV_ENCRYPTED[] = {
 
 static uint8_t KAASYNC_OP_SERV[] = { 0xf0, 0x0e, 0x00, 0x06, 'K', 'a','a','t','c','p', 0x01, 0x00, 0x00, 0x11, 0x34, 0x45 };
 
-#endif //KAA_ENCRYPTION                                    
-                                    
+#endif //KAA_ENCRYPTION
+
 static uint8_t *g_connect_sync_request;
 static size_t g_connect_sync_request_size;
 static uint8_t *g_kaasync_op_serv;
@@ -188,8 +188,8 @@ void test_create_kaa_tcp_channel(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id operation_services[] = {
             KAA_EXTENSION_PROFILE,
@@ -245,8 +245,8 @@ void test_kaa_tcp_channel_success_flow(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id operation_services[] = {
             KAA_EXTENSION_PROFILE,
@@ -281,8 +281,8 @@ void test_kaa_tcp_channel_sync_flow(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id operation_services[] = {
             KAA_EXTENSION_PROFILE,
@@ -333,8 +333,8 @@ void test_kaa_tcp_channel_io_error_flow(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1,sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id operation_services[] = {
             KAA_EXTENSION_PROFILE,
@@ -384,8 +384,8 @@ void test_kaa_tcp_channel_auth_double_sync_flow(void **state)
 
     kaa_error_t error_code;
 
-    kaa_transport_channel_interface_t *channel = NULL;
-    channel = KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
+    kaa_transport_channel_interface_t *channel =
+        KAA_CALLOC(1, sizeof(kaa_transport_channel_interface_t));
 
     kaa_extension_id operation_services[] = {
             KAA_EXTENSION_PROFILE,
@@ -704,7 +704,7 @@ kaatcp_error_t kaatcp_fill_connect_message(uint16_t keepalive, uint32_t next_pro
     if (sync_request == NULL) {
         return KAA_ERR_BADPARAM;
     }
-        
+
     if (sync_request_size == g_connect_sync_request_size) {
         if (!memcmp(g_connect_sync_request, sync_request, sync_request_size)) {
             memset(message, 0, sizeof(kaatcp_connect_t));
@@ -761,10 +761,10 @@ kaa_error_t kaa_platform_protocol_alloc_serialize_client_sync(kaa_platform_proto
         uint8_t **buffer, size_t *buffer_size)
 {
     (void)self;
-    
+
     ASSERT_EQUAL(services_count > 0, true);
     ASSERT_NOT_NULL(services);
-    
+
     uint8_t *alloc_buffer = KAA_MALLOC(sizeof(CONNECT_PACK));
     if (alloc_buffer) {
         memcpy(alloc_buffer, CONNECT_PACK, sizeof(CONNECT_PACK));
@@ -772,7 +772,7 @@ kaa_error_t kaa_platform_protocol_alloc_serialize_client_sync(kaa_platform_proto
         *buffer_size = sizeof(CONNECT_PACK);
         return KAA_ERR_NONE;
     }
-        
+
     return KAA_ERR_BADPARAM;
 }
 
@@ -944,17 +944,17 @@ int test_init(void)
     kaa_error_t error = kaa_log_create(&logger, KAA_MAX_LOG_MESSAGE_LENGTH, KAA_MAX_LOG_LEVEL, NULL);
     if (error || !logger)
         return error;
-    
+
 #ifdef KAA_ENCRYPTION
     kaa_init_rsa_keypair();
-    
+
     g_connect_sync_request_size = ext_get_encrypted_data_size(sizeof(CONNECT_PACK));
     g_connect_sync_request = KAA_MALLOC(g_connect_sync_request_size);
     if (g_connect_sync_request == NULL) {
         return -1;
     }
     ext_encrypt_data(CONNECT_PACK, sizeof(CONNECT_PACK), g_connect_sync_request);
-    
+
     g_kaasync_op_serv_size = sizeof(KAASYNC_OP_SERV_ENCRYPTED);
     g_kaasync_op_serv = KAASYNC_OP_SERV_ENCRYPTED;
     uint8_t *pdata = KAASYNC_OP_SERV_ENCRYPTED + KAASYNC_OP_SERV_DATA_OFFSET;
@@ -962,11 +962,11 @@ int test_init(void)
 #else
     g_connect_sync_request_size = sizeof(CONNECT_PACK);
     g_connect_sync_request = CONNECT_PACK;
-    
+
     g_kaasync_op_serv_size = sizeof(KAASYNC_OP_SERV);
     g_kaasync_op_serv = KAASYNC_OP_SERV;
 #endif
-    
+
     return 0;
 }
 
@@ -978,7 +978,7 @@ int test_deinit(void)
     g_connect_sync_request = NULL;
     g_connect_sync_request_size = 0;
 #endif
-    
+
     kaa_log_destroy(logger);
     return 0;
 }

--- a/client/client-multi/client-c/test/test_kaa_channel_manager.c
+++ b/client/client-multi/client-c/test/test_kaa_channel_manager.c
@@ -356,6 +356,7 @@ void test_get_bootstrap_client_sync_size(void **state)
     error_code = kaa_channel_manager_bootstrap_request_get_size(channel_manager, &actual_size);
     ASSERT_EQUAL(error_code, KAA_ERR_NONE);
     ASSERT_EQUAL(actual_size, 0);
+    ASSERT_EQUAL(channel_count, 0);
 
     kaa_channel_manager_destroy(channel_manager);
 }


### PR DESCRIPTION
cppcheck fails with the following errors:
```
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/src/extensions/user/test/test_kaa_user.c:145: style: Variable 'buf_cursor' is modified but its new value is never used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/src/kaa/kaa_status.c:83: style: Variable 'read_buf_head' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c:164: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c:214: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c:242: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c:284: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_bootstrap.c:351: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c:192: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c:249: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c:285: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c:337: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/kaa_tcp_channel/test_kaa_tcp_channel_operation.c:388: style: Variable 'channel' is reassigned a value before the old one has been used.
/home/travis/build/kaaproject/kaa/client/client-multi/client-c/test/test_kaa_channel_manager.c:353: style: Variable 'channel_count' is modified but its new value is never used.
```

Fix them!